### PR TITLE
minor fixes for 1-5-24

### DIFF
--- a/docs/restaking-guides/0-restaking-user-guide/native-restaking/create-eigenpod/README.md
+++ b/docs/restaking-guides/0-restaking-user-guide/native-restaking/create-eigenpod/README.md
@@ -4,7 +4,7 @@ An [EigenPod](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs
 
 - You may repoint any number of validators to a single EigenPod.
 - An Ethereum address can only deploy a single EigenPod.
-- The address that deploys an EigenPod becomes the owner of the contract, and gains special permissions.
+- The address that deploys an EigenPod becomes the owner of the contract and gains permission for restaking and withdrawal operations.
 - Ownership of an EigenPod cannot be transferred.
 
 **Step 1:** Open the [EigenLayer App](http://app.eigenlayer.xyz/) and connect your Web3 wallet, making sure you are connected to Ethereum mainnet.

--- a/docs/restaking-guides/0-restaking-user-guide/native-restaking/repointing-a-validators-withdrawal-credentials.md
+++ b/docs/restaking-guides/0-restaking-user-guide/native-restaking/repointing-a-validators-withdrawal-credentials.md
@@ -17,7 +17,7 @@ ethdo is a CLI developed by independent Ethereum contributors. It abstracts a lo
 3. Follow the [basic](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md#basic-operation) or [advanced](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md#advanced-operation) guide for changing your validator's withdrawal credentials.
 
 :::info
-**I**nput the address copied in **step 2** as the **`--withdrawal-address`** flag.
+Input the address copied in **step 2** as the **`--withdrawal-address`** flag.
 :::
 
 4. Check that your validator has its withdrawal credentials correctly set by running the following command and replacing **VALIDATOR_INDEX** with your validator's index.

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/create-eigenpod-and-set-withdrawal-credentials/README.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/create-eigenpod-and-set-withdrawal-credentials/README.md
@@ -4,24 +4,24 @@ An [EigenPod](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/docs
 
 - You may repoint any number of validators to a single EigenPod.
 - An Ethereum address can only deploy a single EigenPod.
-- The address that deploys an EigenPod becomes the owner of the contract, and gains special permissions.
+- The address that deploys an EigenPod becomes the owner of the contract and gains permission for restaking and withdrawal operations.
 - Ownership of an EigenPod cannot be transferred.
 
-Step 1: Open the[ EigenLayer App](https://goerli.eigenlayer.xyz/) and connect your Web3 wallet, making sure you are connected to Ethereum mainnet.
+**Step 1:** Open the[ EigenLayer App](https://goerli.eigenlayer.xyz/) and connect your Web3 wallet, making sure you are connected to Ethereum mainnet.
 
 ![](https://lh7-us.googleusercontent.com/HNaZjUx0-Tp6xqPD7T6BVccmiXiwbTLD2g4jw4R87xpGw_XsTAqXXJ1eYIBOeYKZOaQ0RcYBsOr3OrZL0xUG8l6xumGHqAbByRFYHe6Qoe5zeUgHL2fYCWnCi1SNNgIkTIdj8db9t3LHVsAJi6qA5Ys)
 
-Step 2: Review the Terms of Service & Privacy Policy. Click Sign to continue and accept the transaction in your wallet to continue.
+**Step 2:** Review the Terms of Service & Privacy Policy. Click Sign to continue and accept the transaction in your wallet to continue.
 
 ![](https://lh7-us.googleusercontent.com/NAjPWmiVugcK4LBKRe-Sj8bZKf5c9oR-hRmvr0jeQg3XN-eUdlasEru71Zjb59p30QnF-7fUbflVfEMxnfqC9HdQJXV2zpo3E7x1HgJm91bNybpzYbo4er1cPO8fv514uyZVcdT6Xu8GVFQHA6iT1pI)
 
 ![](https://lh7-us.googleusercontent.com/iLPD5MfrJT8krjQtly8sUUiqKtpTWXD58Ajp_jfKNTnNcV07s8TD-A2H0GLyPOmTHvFUWGho7qjICYzzhAvpyTwJh_Mpiq_k6lMWsNL7H5ns9OCVRa6MnjMpFpNDkNakfdTPVRcElFSfslcVJTHByN0)
 
-Step 3: Click Create Pod
+**Step 3:** Click Create Pod
 
 ![](https://lh7-us.googleusercontent.com/JmrdFSRiYNSe_77cpb8ut3ZEH4FIgyO1D4Sm76QM3mi6agrvsXQ1_I6t_CVnZ3hP3YRFrVGPvHWo7rQFxhYylYSO02XTQ02wKFjpRdN1auJDmGJAdJJ6ubmAJ0XfbiEbeH_4n9Aq0VDMBkD_I4g-n_0)
 
-Step 4: Review the fee recipient warning and click Create EigenPod
+**Step 4:** Review the fee recipient warning and click Create EigenPod
 
 ![](https://lh7-us.googleusercontent.com/gCiv9UYN6M4LTyyb78MXQJ9GeXCW-Sf-23FgWOw9JHs7wRvuSjMlfejOVgcc6ymUE0Lu98ojF-k6MZzdeV45KmYlnCM_jjdoecJcdozIacCGqd0cFNet-hdZdJ9iwVkL9-kg9suCQQhkYF9364PK_yQ)
 

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/create-eigenpod-and-set-withdrawal-credentials/create-an-eigenpod-with-safe-optional.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/create-eigenpod-and-set-withdrawal-credentials/create-an-eigenpod-with-safe-optional.md
@@ -2,30 +2,30 @@
 
 Follow the instructions below to create an EigenPod using a Safe address.
 
-Step 1: Create a [Safe{Wallet} Account](https://app.safe.global/) and note the new address created.
+**Step 1:** Create a [Safe{Wallet} Account](https://app.safe.global/) and note the new address created.
 
-Step 2: Locate the current “EigenPodManager -> Proxy” contract address via the[ EigenLayer Goerli Deployments table here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/README.md#m1-current-goerli-testnet-deployment).
+**Step 2:** Locate the current “EigenPodManager -> Proxy” contract address via the[ EigenLayer Goerli Deployments table here](https://github.com/Layr-Labs/eigenlayer-contracts/blob/master/README.md#m1-current-goerli-testnet-deployment).
 
-Step 3: In your Safe{Wallet} Dashboard, click “New Transaction”, then “Transaction Builder”
+**Step 3:** In your Safe{Wallet} Dashboard, click “New Transaction”, then “Transaction Builder”
 
 ![](https://lh7-us.googleusercontent.com/VhvtrzfZkAPIVjAVGaGiQLuHcoX94IeuJIZKymOP8rl5SU6YPkLMRDfyoEKT22MJUwCZp3bj4g7RnkFZPrvNDq1FBRWt6wp6fd_W_qxmdDczCr63Md7v_dFGjMRlA_cPbxAF2vs4pwRk8Y3aIGI5ghY)
 
 ![](https://lh7-us.googleusercontent.com/fWBK0B7_n1MwCLVB7fMI5c75lRaFjLL_UGjSu3ZPxxxefoXl3qfln0UBislng7WoLq2ZXaxIepJJnzDbjWFBa3wv9XZZ-OcR3y10OvDaHzHOIPTH_-BVT3cVZXyOkGybaNCoBuW430fvzkqz5-QhdOE)
 
-Step 4: Paste the EigenPodManager Proxy contract address into the “Enter Address” field. Observe the ABI is automatically pulled in by the Safe UI.
+**Step 4:** Paste the EigenPodManager Proxy contract address into the “Enter Address” field. Observe the ABI is automatically pulled in by the Safe UI.
 
 ![](https://lh7-us.googleusercontent.com/6Amzdvc2bS1qnBHMezLS6iA7w3XNdyW6rKacGeVoY4TiIkvuoRfYp2tJ_xBHoQOYEKSMwcz_IDpbTgXrKV2kedxX30BOVoq3yFiAItv2O03T94CCrDuNGgidDhsKIxO5cv1_G_apMsHDnwzAD8zh3hE)
 
-Step 5: Ensure the Contract Method Selector is set to createPod.
+**Step 5:** Ensure the Contract Method Selector is set to createPod.
 
 ![](https://lh7-us.googleusercontent.com/L-fGo8SfLFRL9eGuclFYLGu6Hcv-J1Hj_taTc-ba7ttThA6c_yiztPylvKgfABkM0v4henpfG4sIrVTWxPdAO_4dfHIk69xRxa9edZaRDjhugWR4O6uf3wwG0-PwBg_BzsSb157d4r4Z123e0mdxQZk)
 
-Step 6: Click Add Transaction then Create Batch to proceed.
+**Step 6:** Click Add Transaction then Create Batch to proceed.
 
-Step 7: Review the transaction and click Send Batch to proceed.
+**Step 7:** Review the transaction and click Send Batch to proceed.
 
 ![](https://lh7-us.googleusercontent.com/A4J5a_mzQcqJiz7xeM2jRzsQv5slK98MANGAdtRS3B5rvOP5v6yyrmYubxbLzR_3uhgIxOmWfQIpDbQmNX2hhhX7-h4eB1dNmFCjKnGoBh6Toikh0G5hshCsyTmbeyEOs0RAdX_YLmyOqa-eg4DN2Ms)
 
-Step 8: Scroll to the bottom of the Confirm transaction screen and select Execute to proceed.
+**Step 8:** Scroll to the bottom of the Confirm transaction screen and select Execute to proceed.
 
 ![](https://lh7-us.googleusercontent.com/UPnY4qM7MtBkzrwI0FZLTo5iAEVkEWUNS-pRCIg0LhL1djbF2NwPjAT4M_PDvgwIMGHOGvk0NwfjCYJUzHzKtY02Y9FZh_FXKpi_lULiNmYYdIUBJFj8MvMI3kT4lMumM470JiKMW_nt-dqPRMaggp8)

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/enable-restaking.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/enable-restaking.md
@@ -10,18 +10,18 @@ After your Beacon chain ETH balance has been proven and verified on chain, you w
 This process can take **up to 4 hours** after your validators have entered the active state on the beacon chain. You may use [beaconcha.in](https://beaconcha.in) as a reference during this process.
 :::
 
-Step 1: Click Restake from the Beacon Chain Ether page.
+**Step 1:** Click Restake from the Beacon Chain Ether page.
 
 ![](/img/testnet-restake-guides/enable-restake-1.png)
 
-Step 2: Observe the app is fetching beacon chain proofs and validating them on-chain.
+**Step 2:** Observe the app is fetching beacon chain proofs and validating them on-chain.
 
 ![](https://lh7-us.googleusercontent.com/TEQS3Nkjxf9NYe382VZ4UqYatO1r0QAtYvLYVmDavOhl7KkD-xyVamKulgxXVIFPe96u0VCs-gVbQ2UR7Oh-ZuktcHYP0Gfozqq2ZRFEpLhct9GXssVXf5ZZui9MmEKubqwekKrg2mPU9wZrDf8ZzPU)
 
 ![](/img/testnet-restake-guides/enable-restake-2.png)
 
-Step 3: Confirm the transaction via your Web3 wallet.
+**Step 3:** Confirm the transaction via your Web3 wallet.
 
-Step 4: Observe your Beacon Chain Restaked and Total Restaked balances have increased accordingly.
+**Step 4:** Observe your Beacon Chain Restaked and Total Restaked balances have increased accordingly.
 
 ![](/img/testnet-restake-guides/enable-restake-3.png)

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/repointing-a-validators-withdrawal-credentials.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/repointing-a-validators-withdrawal-credentials.md
@@ -17,7 +17,7 @@ ethdo is a CLI developed by independent Ethereum contributors. It abstracts a lo
 3. Follow the [basic](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md#basic-operation) or [advanced](https://github.com/wealdtech/ethdo/blob/master/docs/changingwithdrawalcredentials.md#advanced-operation) guide for changing your validator's withdrawal credentials.
 
 :::info
-**I**nput the address copied in **step 2** as the **`--withdrawal-address`** flag.
+Input the address copied in **step 2** as the **`--withdrawal-address`** flag.
 :::
 
 4. Check that your validator has its withdrawal credentials correctly set by running the following command and replacing **VALIDATOR_INDEX** with your validator's index.

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/upgrade-eigenpod.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/upgrade-eigenpod.md
@@ -8,19 +8,19 @@ If your EigenPod was created prior to Stage 2, you will need to upgrade your Eig
 
 EigenLayer Phase 2 enables proving of the state of your validators from the beacon chain to EigenLayer smart contracts to confirm the amount restaked. As a result EigenPods that were created prior to M2 contract upgrades are required to have their balances reset to zero, then generate the proofs through the EigenLayer app in order to ensure proof accounting is accurate.
 
-Step 1: Click Upgrade EigenPod
+**Step 1:** Click Upgrade EigenPod
 
 ![](https://lh7-us.googleusercontent.com/61Hr6KpClvZphbwp8ErDsDHuOKZ6MtLpWKCrjPFtfX7oedLGTZKEf8oDSr-5lBAuIXHsPCU6Zu3pfn5GRSQVGMr_3ZyWYGDwEHG33lqVoOx-b0VwNt_Z8Zd1Oa7UizNFBWlJKpFPx9sRR71VLajWlPI)
 
-Step 2: Review the fee recipient warning and click Continue.
+**Step 2:** Review the fee recipient warning and click Continue.
 
 ![](https://lh7-us.googleusercontent.com/HINccC3vXwq1qQWgwQXNBpKqrpKcNPv16EabLwJEIB0wTfajaCIOdZM0HChbBkzuAA8WnqCb2sSGEOLmKUaOOUgS_w75sJdNRnw2PC0fflk9TE2ZHvcIeBSqMC4ier_W6ziVGzAwXgpMIwdtEyEt814)
 
-Step 3: Review the disclaimer that you are about to trigger a withdrawal of Consensus Rewards from your EigenPod. Click Confirm
+**Step 3:** Review the disclaimer that you are about to trigger a withdrawal of Consensus Rewards from your EigenPod. Click Confirm
 
 ![](https://lh7-us.googleusercontent.com/iW-3_ywJeXlzjnKCZu8lvKKeZVgkOVGuWp_UZKih70iiN-dnVDZwRB0_BnVrScAzjvR_MXe4COzw7u-QdO2si1MpAJuhljHjNekQ7KeDOSzRiz3nrytVd5LbbuaMVqd_AuXUVZ4DsiW5HlXcSZtL6xM)
 
-Step 4: Observe the Restaking Activated confirmation and explanation that Restaking will be available after the next beacon state update.
+**Step 4:** Observe the Restaking Activated confirmation and explanation that Restaking will be available after the next beacon state update.
 
 ![](https://lh7-us.googleusercontent.com/vPmsNTcLVtLEeP1vqMRzi654epk7rTIx5fbB7aJTVPK6b7mGdrNdmTriyAFBuQrcU4hu1AYUf46ZM7PFe0SGU-QA9BeZQI506I6goJbNvTNROGxCoRX36E1KNk3irLV72vXP0-jTNmp73h_QS8L4wlI)
 

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/withdraw-from-eigenlayer/full-withdrawal.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/withdraw-from-eigenlayer/full-withdrawal.md
@@ -5,20 +5,20 @@ Ensure you have already repointed your withdrawal credentials to your EigenPod b
 
 All funds unstaked from EigenLayer go through a escrow period before being able to be withdrawn. After you unstake and queue the withdrawal, you must wait for the escrow period to end before being able to withdraw your assets.
 :::
-
-Step 1: Enter the amount in the text box next to the Unstake button.
+ 
+**Step 1:** Enter the amount in the text box next to the Unstake button.
 
 You can queue a withdrawal for any amount. However, when you choose to complete the withdrawal, you will be required to exit enough validators and have the proofs generated for the required amount.
 
 ![](https://lh7-us.googleusercontent.com/Iil3RwJtYPpGzrPFVjgwUvYmHwTdUk2tExBTvAOEN-tTzXa83LXQIwr8F1oTHM561YQMCpHEqVZWggqE75pjAmduoIoHaBqY7HpnKWbkE6k46QQTeBvOfnFZ0KYLJSIUsXyeS0mCtOMZehMRmBxy_Q8)
 
-Step 2: Click Unstake. Sign the transaction using your Web3 wallet.
+**Step 2:** Click Unstake. Sign the transaction using your Web3 wallet.
 
-Step 3: Observe the Unstaking balance has increased during the escrow period.
+**Step 3:** Observe the Unstaking balance has increased during the escrow period.
 
 ![](https://lh7-us.googleusercontent.com/QZvihKxzjPXs4XBWp8xNZdsc8FmLl7VuJ0m5yom_TqgqiFkpROSVSqEr_4XdMWMmhD-ZcTVOjRYxEaTmwpQzIz87dJdgpNs79jDQvw7TKgNxIXr3P1OJCsWeKZoew4I2iG_6Phy5rlej99HvuoKnY-g)
 
-Step 4: Observe the Unstaked Beacon Chain balance has increased after the escrow period.
+**Step 4:** Observe the Unstaked Beacon Chain balance has increased after the escrow period.
 
 :::warning
 At this point you must exit your beacon chain validators prior to continuing. The validators must have completely exited from the validator queue before continuing. You may use [beaconcha.in](https://beaconcha.in) as a reference during this process.
@@ -28,7 +28,7 @@ After your validators have exited, the Execution Chain amount should increase by
 
 The Redeposit button is available at this point to allow the user to Restake back into EigenLayer in case the withdrawal was queued by mistake.
 
-Step 5: Once your validator has been exited click Withdraw to complete your deposit. Sign the transaction using your Web3 wallet.
+**Step 5:** Once your validator has been exited click Withdraw to complete your deposit. Sign the transaction using your Web3 wallet.
 
 :::info
 Redelegation is available for a user who accidentally queues a withdrawal, but would like to resume staking and delegation without having to exit and re-enter their validators from the beacon chain.

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/withdraw-from-eigenlayer/partial-withdrawals.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-native-restaking/withdraw-from-eigenlayer/partial-withdrawals.md
@@ -10,25 +10,25 @@ Partial withdrawals require on-chain proofs in order to process the withdrawal. 
 
 The proving cost is 200k gas + a fixed fee per proof that will be around 0.01 ETH. Each of these proofs will be able to prove up to 16 beacon chain withdrawals (batched into one transaction). The user will be prompted to sign additional transactions - one per each additional batch.
 
-Step 1: Note the Validator ETH Yield and Redeemable value. The Redeemable value may be lower than the Validator ETH Yield (beacon chain) due to the time lag associated with the beacon chain oracle, which occurs approximately every 4 hours.
+**Step 1:** Note the Validator ETH Yield and Redeemable value. The Redeemable value may be lower than the Validator ETH Yield (beacon chain) due to the time lag associated with the beacon chain oracle, which occurs approximately every 4 hours.
 
 ![](https://lh7-us.googleusercontent.com/315HLw5gMxldCg7bdYEiAVkXkroCylpev1HAjVRwnixIoU9PTy1l-czPnDH3JBqN3oZwand47yxjTqTpdglHzGXRjXEztnnPW8_lQ0p8SvlE-R9sCP4qk7oJMc8hxMM8-koAMLy1DCaU4T0peaUyJZs)
 
-Step 2: Click Redeem to initiate the escrow period.
+**Step 2:** Click Redeem to initiate the escrow period.
 
 ![](https://lh7-us.googleusercontent.com/X2Ipqen9fpnIPp1dnn6g8hFBtpFZr_t7zoBHPHKZ5AvNrxH4Ai1HFqwjuM2YMvEWJgRfmanLYaeg7XwVT-WDtIEv6B9Q6XvgFuXSaTW2OEg20umVOpgSEQQKV2UgDfJH1S0NjuC7fEMGv298ABcvw_s)
 
-Step 3: Observe the gas fee warning. Click Continue.
+**Step 3:** Observe the gas fee warning. Click Continue.
 
 ![](https://lh7-us.googleusercontent.com/eWXzCzR9Q-pbscHZm0na5rcFgpu9l5qPHYbbmPIR7z9hcoFVgpDWS0Aaqi4wUiG6FVRhdvROAalDFdZI6mTHhNalInIQr7JeJQNWG_FlYyxads4HkkuAmvMbFjDRCMm6xxWXig-S9xLkhYeJp_6s86s)
 
-Step 4: Enter the amount you wish to withdraw. Click Confirm.
+**Step 4:** Enter the amount you wish to withdraw. Click Confirm.
 
 ![](https://lh7-us.googleusercontent.com/c9QOI7vNtpvAq4uOIZ_KCrrWyQLO_BDHZIpbXrIyz0fiMj3fKtlYPJlGx6L3S_sbYbSRyUetRv88qFjzlwkj0d96HtDWK0Yn-vUsv4_zTCxv4bZb7DuOcc7JKPGXY8hwyESrikWbyof9XkpREiIAwDw)
 
 If the Awaiting Restake value is greater than zero, the confirmation step above will generate proofs to restake that amount first.
 
-Step 5: Observe the Fetching Proofs status message. Proofs will be submitted on chain and you will be prompted to sign the transaction to proceed.
+**Step 5:** Observe the Fetching Proofs status message. Proofs will be submitted on chain and you will be prompted to sign the transaction to proceed.
 
 Note: if the user has more than 16 partial withdrawal transactions queued on the beacon chain, additional transactions will be generated for each batch of partial withdrawals in increments of 16 partial withdrawals.
 
@@ -36,7 +36,7 @@ Note: if the user has more than 16 partial withdrawal transactions queued on the
 
 Observe the Unstaking balance has increased after the transaction is confirmed on chain.
 
-Step 6: Click Withdraw after the escrow period to withdraw funds. Two wallet transactions will be generated for you to approve and proceed.
+**Step 6:** Click Withdraw after the escrow period to withdraw funds. Two wallet transactions will be generated for you to approve and proceed.
 
 ![](https://lh7-us.googleusercontent.com/yK-i-_zMD8KhpiiHVE_59bOwxBQuZEp0IlhfFCNqY7jYiNHwW9o4h3DF4R8Msu1kV4VboDo_WfhFHQC70ezd0QECKsqg4idohNll2vSiyk2s4Mjq0LL0ip_lRma0x708qzXuC97M5f12wlOT13kRiSk)
 

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-restaker-delegation/delegate-to-an-operator.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-restaker-delegation/delegate-to-an-operator.md
@@ -2,24 +2,24 @@
 
 Follow these steps to initiate delegation of your restaked balance to an Operator. Delegation is an all or nothing operation. You must delegate all of your available Restaked balance to a single Operator.
 
-Step 1: Navigate to the Operator tab to view a list of available Operators.
+**Step 1:** Navigate to the Operator tab to view a list of available Operators.
 
 ![](https://lh7-us.googleusercontent.com/Nr-KLQTJF5C3Flo0YL1iqruUWPBvIdLnjetLh1fyfPnFr8ziUaCOJZE6FV6MpHcSsJikqrviHqCxAPsvVXBJDT6YbH8_Y0LKt8bvMPQ60RwViNOfw6CwdAw9i4T9P11hRMY2VF4et7bmERutEkSYkJM)
 
-Step 2: Search for operators via their name or Ethereum address. Click on the Operator tile to view their Detail page.
+**Step 2:** Search for operators via their name or Ethereum address. Click on the Operator tile to view their Detail page.
 
 ![](https://lh7-us.googleusercontent.com/z3oR0kwjxB8nk66ebFuRRVh8T90fIpWSdEDvbaydgghNnmqrUxhb4RIRhO5HvtUdJfPMICshYA7NM9Ifn637zv8QJa9HUipLDPD_KcddXjAhVadRyrjyuKDQXdzHzKnmcYsHQC9dzxJqA9Pf1qdb8dQ)
 
-Step 3: Click Delegate to initiate a delegation of all your staked assets to that operator.
+**Step 3:** Click Delegate to initiate a delegation of all your staked assets to that operator.
 
-Step 4: Confirm the transaction in your Web3 wallet.
+**Step 4:** Confirm the transaction in your Web3 wallet.
 
-Step 5: Note the delegating progress message.
+**Step 5:** Note the delegating progress message.
 
 ![](https://lh7-us.googleusercontent.com/f095JZRoCQKZ517ztnYPycUR2XljZRi5QkRsynahH7AZHdjONMCaRRugPwVv1WfG0ryPGaY-4f-z3P8-hwdkrKatwEtrZ8p-gbKZoDdP6t7KIFw37KU5CSbyAqvuBkbqkuEyWuPLoXgcGvw205Rd5O4)
 
-Step 6: Note your delegated balance reflects all of your available restaked funds.
+**Step 6:** Note your delegated balance reflects all of your available restaked funds.
 
 ![](https://lh7-us.googleusercontent.com/JUd_5rwSzM_v0riAYdX2_37nKhRdr2Rq0adsPITsnUVuFOxvYb5keIpFe49ZVdgEWfI8YVXnmBeOj2iH5KzCb8-GuuXJIvujXXH8_HxxEUa2TUFhKjFJlfe9HDnezqI5iIMhlmZItBEAmxxrZ3FA0nE)
 
-\
+

--- a/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-restaker-delegation/undelegate-from-an-operator-and-initiate-withdrawal.md
+++ b/docs/restaking-guides/0-restaking-user-guide/stage-2-testnet/testnet-restaker-delegation/undelegate-from-an-operator-and-initiate-withdrawal.md
@@ -6,16 +6,16 @@ Restakers can Undelegate their balance from an Operator at any time. Undelegatio
 Initiating an Undelegate transaction will also automatically queue a withdrawal (Unstake) of your funds. The Undelegate and Queue Withdrawal transactions are combined due to the security architecture of EigenLayer smart contracts.
 :::
 
-Step 1: Navigate to the Operator tab, click the tile for the Operator you have delegated your funds to. Click the Undelegate button to continue.
+**Step 1:** Navigate to the Operator tab, click the tile for the Operator you have delegated your funds to. Click the Undelegate button to continue.
 
 ![](https://lh7-us.googleusercontent.com/SzsWbRMQ-9NYYfah1kBT89hfCZSEvd04Rtk_G1J1en31FbZHEYalivDgIsH-E7sHrKtLQUEFIcq7CdmMvCrFXO3_qYpts5t__y3YMSuqH3GiQa95MrE-BRfHlFDkaqlAolLVXCiybmHm48TZdRLEQMI)
 
-Step 2: Confirm the two transactions in your Web3 wallet.
+**Step 2:** Confirm the two transactions in your Web3 wallet.
 
-Step 3: Observe that your Restaked balance is now 0.0 ETH.
+**Step 3:** Observe that your Restaked balance is now 0.0 ETH.
 
 ![](https://lh7-us.googleusercontent.com/DStQhIFho5ga5_1h945XDiJGtnQvrEy_KzXm1jnhCCysFWJCV2JoOSnEY4xX35loBDGw-tjjoWq_vUAGICkyR9Gz0eUplNKsuDJkp73rFOFMwd2NQYE5Gs_cVZ7riCGsF7j86PARHtyhf14PH3sKb2Y)
 
-Step 4: Visit the Token tab and relevant asset page to observe your Unstaked balance has increased the corresponding amount.
+**Step 4:** Visit the Token tab and relevant asset page to observe your Unstaked balance has increased the corresponding amount.
 
 ![](https://lh7-us.googleusercontent.com/7-TpReNxUQnJlp0W_KqCyaQf7osXcMwHFDKaAybtmTUgEhGmdHreUrAE0jPj7ZZisKqaLhIhkZtksYFz3r8_KShhr-92FyA6pERdXbQhzZQ4bZlceEDIKhR-M_wutvom_JTc8E9h-GSfl3jxDxdf6EE)

--- a/docs/restaking-guides/1-restaking-developer-guide.md
+++ b/docs/restaking-guides/1-restaking-developer-guide.md
@@ -10,7 +10,5 @@ We are dedicated to providing a more robust support framework for direct smart c
 
 
 Resources:
-
-* [EigenLayer Protocol Developer Docs](https://github.com/Layr-Labs/eigenlayer-contracts/tree/master/docs): latest protocol specifications for developers.
-* [EigenLayer Protocol Developer Docs](https://github.com/Layr-Labs/eigenlayer-contracts/tree/master/docs): latest protocol specifications for developers.
+* [EigenLayer Protocol Developer Docs](https://github.com/Layr-Labs/eigenlayer-contracts#documentation): latest protocol specifications for developers.
 * [Contract Addresses](https://github.com/Layr-Labs/eigenlayer-contracts#deployments): deployed contract addresses for Ethereum mainnet.


### PR DESCRIPTION
- [Restaking Guide](https://docs.eigenlayer.xyz/restaking-guides/restaking-developer-guide): remove duplicate line “EigenLayer Protocol Developer Docs: ” at the bottom of the page.
- [Restaking Guide](https://docs.eigenlayer.xyz/restaking-guides/restaking-developer-guide): update the hyperlink to point to here: https://github.com/Layr-Labs/eigenlayer-contracts#documentation
- [Restaking Guide: Testnet Partial Withdrawals](https://docs.eigenlayer.xyz/restaking-guides/restaking-user-guide/stage-2-testnet/testnet-native-restaking/withdraw-from-eigenlayer/partial-withdrawals)
  - Highlight the “Note the Validator ETH Yield and Redeemable value. ..” section
- Testnet Restaking Guides
  - Add Bolding to each “Step X” prompt
- Create EigenPods page (Mainnet and Testnet):
  - Modify text to read: "The address that deploys an EigenPod becomes the owner of the contract and gains permission for restaking and withdrawal operations."