### PR TITLE
fix(operator-installation): fix text for checking if GOBIN is in PATH

### DIFF
--- a/docs/operator-guides/operator-installation.md
+++ b/docs/operator-guides/operator-installation.md
@@ -71,7 +71,7 @@ Now we’re going to install the eigenlayer-CLI using Go. The following command 
 go install github.com/Layr-Labs/eigenlayer-cli/cmd/eigenlayer@latest
 ```
 
-To check if the GOBIN is not in your PATH, you can execute echo $GOBIN from the Terminal. If it doesn't print anything, then it is not in your PATH. To add GOBIN to your PATH, add the following lines to your $HOME/.profile:
+To check if the GOBIN is not in your PATH, you can execute `echo $GOBIN` from the Terminal. If it doesn't print anything, then it is not in your PATH. To add GOBIN to your PATH, add the following lines to your $HOME/.profile:
 
 ```
 export GOBIN=$GOPATH/bin


### PR DESCRIPTION
Small fix to checking if GOBIN is in path, text formatting got wonky.
Before:
![image](https://github.com/Layr-Labs/eigenlayer-docs/assets/89751539/ad3f55a8-7edf-4291-bb59-cadfeec492fc)

After:
![image](https://github.com/Layr-Labs/eigenlayer-docs/assets/89751539/505d3717-44a8-4e83-9949-98c7576f93c0)
