### PR TITLE
Guardrails: removing reference to LST limit, cleaning up language

### DIFF
--- a/docs/security/guardrails.md
+++ b/docs/security/guardrails.md
@@ -15,9 +15,6 @@ In the interest of caution with regards to protocol security, EigenLayer is laun
 
 In addition, the protocol facilitates native restaking, allowing users to create EigenPods and assign the withdrawal credentials of multiple validators to the addresses of their EigenPods.
 
-The following restaking limits and conditions are in place:
-
-* Within Liquid restaking, there is a deposit limit of 32 tokens per user transaction.
-* There will be a 7-day withdrawal delay that will serve as a security measure during the early stages of the EigenLayer mainnet, to optimize for the safety of assets. This withdrawal lag, which is common in staking protocols, is required when AVSs go live, as there is a lag to verify that activity associated with any AVS was completed successfully.
+There will be a 7-day [withdrawal delay](withdrawal-delay.md) that will serve as a security measure during the early stages of the EigenLayer mainnet, to optimize for the safety of assets. This withdrawal lag, which is common in staking protocols, is required when AVSs go live, as there is a lag to verify that activity associated with any AVS was completed successfully.
 
 Read the [user guide to liquid restaking here](https://docs.eigenlayer.xyz/guides/liquid-restaking) and the [user guide to native restaking here](https://docs.eigenlayer.xyz/restaking-guides/restaking-user-guide/native-restaking).


### PR DESCRIPTION
Removing reference to LST limit, cleaning up language