### PR TITLE
Add PR checks for broken links

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,40 @@
+name: PR Check Workflow
+
+on:
+  pull_request:
+    branches:
+      - main
+  
+jobs:
+  check-PR:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout base commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Generate routes
+        run: |
+          ./ci-scripts/gen_routes.sh > routes_to_test.txt
+
+      - name: Upload routes file
+        uses: actions/upload-artifact@v2
+        with:
+          name: routes-to-test
+          path: routes_to_test.txt
+
+      - name: Checkout PR's head commit
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Download routes file
+        uses: actions/download-artifact@v2
+        with:
+          name: routes-to-test
+
+      - name: Run redirect tests
+        run: |
+          ./ci-scripts/test_redirects.sh routes_to_test.txt

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test-redirects
+
+test-redirects:
+	@./ci-scripts/test_redirects_local.sh

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 ### Installation
 
 ```
-$ yarn
+yarn
 ```
 
 ### Local Development
 
 ```
-$ yarn start
+yarn start
 ```
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +19,7 @@ This command starts a local development server and opens up a browser window. Mo
 ### Build
 
 ```
-$ yarn build
+yarn build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
@@ -29,13 +29,13 @@ This command generates static content into the `build` directory and can be serv
 Using SSH:
 
 ```
-$ USE_SSH=true yarn deploy
+USE_SSH=true yarn deploy
 ```
 
 Not using SSH:
 
 ```
-$ GIT_USER=<Your GitHub username> yarn deploy
+GIT_USER=<Your GitHub username> yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.

--- a/ci-scripts/gen_routes.sh
+++ b/ci-scripts/gen_routes.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+source ./ci-scripts/run_with_status.sh
+
+run_with_status "Building old site" yarn build
+sed 's/xmlns="[^"]*"//g' build/sitemap.xml | xmllint --xpath '//*[local-name()="loc"]/text()' - | while read -r url; do
+  echo "${url#https://docs.eigenlayer.xyz}"
+done

--- a/ci-scripts/run_with_status.sh
+++ b/ci-scripts/run_with_status.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+
+run_with_status() {
+    local description="$1"
+    shift  # Remove the first argument, leaving only the command and its arguments
+
+    # Print the description to stderr
+    echo -n "$description... " >&2
+
+    # Execute the command, capturing both stdout and stderr.
+    # Use a temporary file to capture the output
+    local temp_file=$(mktemp)
+    if ! "$@" >"$temp_file" 2>&1; then
+        # If the command fails, indicate an error and show the output
+        echo "error." >&2
+        echo "" >&2
+        cat "$temp_file" >&2
+        rm -f "$temp_file"
+        return 1
+    else
+        # If the command succeeds, indicate completion
+        echo "done." >&2
+        rm -f "$temp_file"
+        return 0
+    fi
+}

--- a/ci-scripts/test_redirects.sh
+++ b/ci-scripts/test_redirects.sh
@@ -1,0 +1,89 @@
+#!/bin/bash -e
+
+source ./ci-scripts/run_with_status.sh
+
+# Display usage information
+usage() {
+    echo "Usage: $0 <filename>"
+    echo
+    echo "This script tests that each of the old pages redirects properly to a new page."
+    echo "It requires a file containing URLs to test, one per line."
+    echo
+    echo "Usage pattern:"
+    echo "1. Switch from new branch to old branch"
+    echo "2. Generate routes get_routes.sh > routes_to_test.txt"
+    echo "3. Switch from old branch to new branch (bringing routes_to_test.txt over)"
+    echo "4. Run $0 routes_to_test.txt"
+    echo ""
+    echo "This script tests that each of the old pages redirects properly to a new page."
+    echo "It does not test that this is the correct new page however."
+    exit 1
+}
+
+# Ensure server is killed on script exit
+cleanup() {
+    if [ ! -z "$SERVER_PID" ]; then
+        kill $SERVER_PID 2>/dev/null || echo "Server process not found."
+    else
+        echo "No server was started."
+    fi
+}
+
+# Variable to track test failure
+any_fail=0
+
+
+# Check for help option or no argument
+if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]] || [ "$#" -ne 1 ]; then
+    usage
+fi
+
+
+# Absolute path to the filename
+FILENAME=$(realpath "$1")
+
+# Ensure file exists
+if [ ! -f "$FILENAME" ]; then
+    echo "File not found: $FILENAME" >&2
+    exit 1
+fi
+
+# Build the project and start the server
+
+run_with_status "Building new site" yarn build
+printf "Starting server... "
+./node_modules/.bin/docusaurus serve --no-open &>/dev/null &
+SERVER_PID=$!
+# Wait a bit for the server to start
+sleep 5
+printf "done.\n"
+
+# Setup trap to clean up on script exit
+trap cleanup EXIT
+
+echo ""
+echo "Begining tests"
+echo ""
+while IFS= read -r url; do
+    full_url="http://localhost:3000${url}"
+    # Perform a curl request and check both for "Page Not Found" and curl's exit status
+    if ! curl_output=$(curl -fs "$full_url" 2>&1); then
+        # Curl command failed
+        printf "\033[31mFAIL\033[0m: %s\n" "$full_url" >&2
+        any_fail=1
+    else
+        # If curl succeeded and "Page Not Found" not in output, mark test as passed
+        printf "\033[32mPASS\033[0m: %s\n" "$full_url"
+    fi
+done < "$FILENAME"
+
+# Exit with status code 1 if any test failed
+if [ "$any_fail" -eq 1 ]; then
+    echo ""
+    printf "\033[31mOne or more tests failed!\033[0m\n"
+    exit 1
+else
+    echo ""
+    printf "\033[32mAll tests passed!\033[0m\n"
+    exit 0
+fi

--- a/ci-scripts/test_redirects_local.sh
+++ b/ci-scripts/test_redirects_local.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -e
+
+source ./ci-scripts/run_with_status.sh
+
+REPO_TOP_LEVEL=$(git rev-parse --show-toplevel)
+
+# Fetch the latest state of origin/main
+run_with_status "Fetching origin" git fetch origin main
+
+# Find the merge-base of the current branch and origin/main
+MERGE_BASE=$(git merge-base origin/main @)
+
+# echo "Merge base of origin/main and $CURRENT_BRANCH is $MERGE_BASE"
+
+# Generate a random worktree path
+WORKTREE_PATH="/tmp/pr_worktree_$(date +%Y%m%d%H%M%S)_$RANDOM"
+
+# Ensure the worktree path is unique and does not already exist
+if [ -d "$WORKTREE_PATH" ]; then
+    echo "Worktree directory already exists. Please try again."
+    exit 1
+fi
+
+# Create a new worktree for the merge-base in the temporary directory
+run_with_status "Creating worktree" git worktree add "$WORKTREE_PATH" $MERGE_BASE
+
+# Change directory to the worktree
+cd "$WORKTREE_PATH"
+
+run_with_status "Linking dependencies" yarn
+
+# Run the script to generate the routes_to_test.txt
+./ci-scripts/gen_routes.sh > routes_to_test.txt
+
+# Move the routes_to_test.txt back to the original repo directory
+run_with_status "Copying routes" mv routes_to_test.txt "$REPO_TOP_LEVEL"
+
+# Clean up the worktree and return to the original repository directory
+run_with_status "Removing worktree" git worktree remove "$WORKTREE_PATH"
+cd - &>/dev/null
+
+# The current repo state is now the target for tests
+# Run the tests with the routes file in the current state of the repository
+set +e
+./ci-scripts/test_redirects.sh routes_to_test.txt
+TEST_REDIRECTS_EXIT_CODE=$?
+set -e
+
+rm routes_to_test.txt


### PR DESCRIPTION
Should fail any PR that breaks a link that used to work.

The check fails in this PR because the script used in the "base" commit does not exist yet, so the check must be overriden.