### PR TITLE
Add newlines at the 80 character column so md files can easily be edited in a code editor

### DIFF
--- a/docs/eigenda/blob-explorer.md
+++ b/docs/eigenda/blob-explorer.md
@@ -4,10 +4,13 @@ sidebar_position: 3
 
 # Blob Explorer
 
-The purpose of the Blob Explorer is to show Blobs and summary statistics. The main features of the Blob Explorer include:
+The purpose of the [Blob Explorer](https://blobs-goerli.eigenda.xyz/) is to show
+blob metadata and summary statistics for debugging and monitoring purposes.
 
-* The throughput data from the last hour
-* Display the last 100 blobs
-* Display details on a single blob for a given blob key
+<!-- TODO: Check whether we can see actual blobs on the blob explorer now -->
 
-In order to access the Blob Explorer, please visit [https://blobs-goerli.eigenda.xyz/](https://blobs-goerli.eigenda.xyz/).
+The Blob Explorer makes available:
+
+* Throughput data for the last hour
+* The contents of the last 100 blobs published
+* A view of blob metadata for any given blob key

--- a/docs/eigenda/deployed-contracts.md
+++ b/docs/eigenda/deployed-contracts.md
@@ -14,7 +14,11 @@ No contracts have been deployed to mainnet yet.
 
 ### Current Testnet Deployment
 
-The current testnet deployment of EigenDA is [`v0.3.0`](https://github.com/Layr-Labs/eigenda/releases/tag/v0.3.0) part of which includes middleware contracts from the [`v0.1.1-goerli-m2`](https://github.com/Layr-Labs/eigenlayer-middleware/tree/testnet) release. Below are the deployed contract addresses and links to source.
+The current testnet deployment of EigenDA is
+[`v0.3.0`](https://github.com/Layr-Labs/eigenda/releases/tag/v0.3.0) part of
+which includes EigenLayer middleware contracts from the
+[`v0.1.1-goerli-m2`](https://github.com/Layr-Labs/eigenlayer-middleware/tree/testnet)
+release. Below are the deployed contract addresses and links to source.
 
 | Name                           | Solidity                                                                                                   | Proxy                                                          | Implementation                                                | Notes                                                                                                            |
 |--------------------------------|------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|---------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|

--- a/docs/eigenda/operator-guides/eigenda-metrics-and-monitoring.md
+++ b/docs/eigenda/operator-guides/eigenda-metrics-and-monitoring.md
@@ -5,7 +5,8 @@ description: Setup Grafana and Prometheus Metrics and Monitoring Stack
 
 # EigenDA Metrics and Monitoring
 
-These instructions provide a quickstart guide to run the Prometheus, Grafana, and Node exporter stack.
+These instructions provide a quickstart guide to run the Prometheus, Grafana,
+and Node exporter stack.
 
 **Step 1:** Move your current working directory to the monitoring folder:
 
@@ -16,7 +17,8 @@ cp .env.example .env
 
 - Open the `.env` file, ensure the location of `prometheus.yml` is correct for your environment.
 - In the `prometheus.yml` file:
-  - Update prometheus config [file](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/monitoring/prometheus.yml) is updated with the metrics port (`NODE_METRICS_PORT`) of the eigenda node in parent folder `.env` file
+  - Update prometheus config [file](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/monitoring/prometheus.yml)
+    is updated with the metrics port (`NODE_METRICS_PORT`) of the eigenda node in parent folder `.env` file
   - Ensure the eigenda container name for `scrape_configs.targets` matches the value of the parent folder `.env` file (`MAIN_SERVICE_NAME`).
   - Make sure the location of prometheus file is correct in [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/monitoring/.env.example) file
 
@@ -26,14 +28,22 @@ cp .env.example .env
 docker compose up -d
 ```
 
-**Step 3:** Since eigenda is running in a different docker network we will need to have prometheus in the same network. To do that, run the following command
+**Step 3:** Since eigenda is running in a different docker network we will need
+to have prometheus in the same network. To do that, run the following command
 
 ```
 docker network connect eigenda-network prometheus
 ```
 
-Note: `eigenda-network` is the name of the network in which eigenda is running. You can check the network name in eigenda [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/.env.example#L2) file (`NETWORK_NAME`). This will ensure Prometheus can scrape the metrics from Eigenda node.
+Note: `eigenda-network` is the name of the network in which eigenda is running.
+You can check the network name in eigenda
+[.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/.env.example#L2)
+file (`NETWORK_NAME`). This will ensure Prometheus can scrape the metrics from
+Eigenda node.
 
-Useful Dashboards: EigenDA offers a set of [Grafana dashboards](https://github.com/Layr-Labs/eigenda-operator-setup/tree/master/monitoring/dashboards) that are automatically imported when initializing the monitoring stack.
+Useful Dashboards: EigenDA offers a set of [Grafana
+dashboards](https://github.com/Layr-Labs/eigenda-operator-setup/tree/master/monitoring/dashboards)
+that are automatically imported when initializing the monitoring stack.
 
-If you prefer to set up the metrics and monitoring stack manually, follow the steps located [here](https://github.com/Layr-Labs/eigenda-operator-setup#metrics).
+If you prefer to set up the metrics and monitoring stack manually, follow the
+steps located [here](https://github.com/Layr-Labs/eigenda-operator-setup#metrics).

--- a/docs/eigenda/operator-guides/ejection-non-signing.md
+++ b/docs/eigenda/operator-guides/ejection-non-signing.md
@@ -4,21 +4,37 @@ sidebar_position: 5
 
 # Ejection Due to Non-Signing
 
-EigenDA Operators are responsible for receiving data blobs, securely storing them, and providing digital signatures for these blobs as requested by the Disperser. The system has specific consequences if Operators fail to sign the requested blobs:
+EigenDA Operators are responsible for receiving data blobs, securely storing
+them, and providing digital signatures for these blobs as requested by the
+Disperser. The system has specific consequences if Operators fail to sign the
+requested blobs:
 
-1. **Increased Gas Costs:** In the EigenDA network, the gas costs to the protocol escalate proportionally with the number of Operators who do not sign the blobs. This means that as more Operators refrain from signing and the longer they remain non-responsive, the higher the Ethereum (ETH) gas costs become for the entire network.
-2. **Impact on Quorum Liveness:** The reliability of the quorum is compromised if a significant number of Operators cease signing operations. This can lead to a failure in processing requests that require a higher quorum threshold, as there won't be enough signatures to meet the necessary criteria.
+1. **Increased Gas Costs:** In the EigenDA network, the gas costs to the
+protocol escalate proportionally with the number of Operators who do not sign
+the blobs. This means that as more Operators refrain from signing and the longer
+they remain non-responsive, the higher the Ethereum (ETH) gas costs become for
+the entire network.
+2. **Impact on Quorum Liveness:** The reliability of the
+quorum is compromised if a significant number of Operators cease signing
+operations. This can lead to a failure in processing requests that require a
+higher quorum threshold, as there won't be enough signatures to meet the
+necessary criteria.
 
 ## Manual and Automated Ejection of Non-Compliant Operators
 
-Operators who consistently fail to return signatures to the Disperser will be subject to removal by the EigenDA team. Initially, this ejection process will be conducted manually. Over time, however, it will transition to an automated system, with the protocol itself handling the ejection of Operators who do not adhere to the required standards of operation.
+Operators who consistently fail to return signatures to the Disperser will be
+subject to removal by the EigenDA team. Initially, this ejection process will be
+conducted manually. Over time, however, it will transition to an automated
+system, with the protocol itself handling the ejection of Operators who do not
+adhere to the required standards of operation.
 
 # Ejection Criteria for EigenDA Operators
 
 Operators with **less than 4% stake**
 
-* Warning Issued: If an operator drops more than 10% of requests within a 48-hour period.
-* Ejection Policy: Operators will be ejected if they fail to address the issue within 48 hours following the warning.
+* Warning Issued: If an operator drops more than 10% of requests within a
+  48-hour period.  Ejection Policy: Operators will be ejected if they fail to
+* address the issue within 48 hours following the warning.
 
 Operators with a **stake of 4% or more**  
 
@@ -29,6 +45,9 @@ Operators with a **stake of 4% or more**
   * Warning Issued: If an operator drops more than 10% of requests within a 6-hour period.
   * Ejection Policy: Operators will be ejected if they fail to address the issue within 6 hours following the warning.
 
-This structured approach ensures a fair and responsive mechanism for maintaining network integrity, with different thresholds based on the operator's stake and the overall network performance. Please note the criteria may change over time.
+This structured approach ensures a fair and responsive mechanism for maintaining
+network integrity, with different thresholds based on the operator's stake and
+the overall network performance. Please note the criteria may change over time.
 
-_\*Percentage of active stake vs. total stake. This will be monitored by how much stake has signed the last batch._
+_\*Percentage of active stake vs. total stake. This will be monitored by how
+much stake has signed the last batch._

--- a/docs/eigenda/operator-guides/ip-stability-and-costs-of-change.md
+++ b/docs/eigenda/operator-guides/ip-stability-and-costs-of-change.md
@@ -4,7 +4,9 @@ sidebar_position: 4
 
 # IP Stability & Costs of Change
 
-It is important to ensure that your EigenDA Node service (addressed by IP:Port, which needs to register on-chain) is reachable from the internet. The chart below summarizes the potential IP sharing and stability options for Operators.
+It is important to ensure that your EigenDA Node service (addressed by IP:Port,
+which needs to register on-chain) is reachable from the internet. The chart
+below summarizes the potential IP sharing and stability options for Operators.
 
 |                        | Shared IP                                                                                                                           | Dedicated IP                                                                                                                                                     |
 | ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/eigenda/operator-guides/operator-faq.md
+++ b/docs/eigenda/operator-guides/operator-faq.md
@@ -13,16 +13,23 @@ You can search using the below EigenLayer webapp links:
 
 #### I opted in into running EigenDA but I am not in the operator set anymore. What happened?
 
-Either you are [churned out](./overview.md#eigenda-churn-approver) by an other operator or you have been [ejected due to non-signing](./ejection-non-signing.md). If none of this reason applies, please reach out to EigenLayer Support
+Either you are [churned out](./overview.md#eigenda-churn-approver) by an other
+operator or you have been [ejected due to non-signing](./ejection-non-signing.md).
+If none of this reason applies, please reach out to EigenLayer Support
 
 #### How do I know if my node is signing EigenDA blobs correctly?
 
 There are few ways you can confirm that your node is signing the blobs
 
-* Ensure that you have monitoring setup according to the [guide](./eigenda-metrics-and-monitoring.md). Once you have added the provided EigenDA Grafana dashboards, take a look at the graph saying **EigenDA number of processed batches**. This graph should be increasing like below graph:
-![EigenDA correct sign](/img/operator-guides/avs-installation-and-registration/eigenda-operator-guide/eigenda-correct-sign.png)
+* Ensure that you have monitoring setup according to the
+ [guide](./eigenda-metrics-and-monitoring.md). Once you have added the provided
+ EigenDA Grafana dashboards, take a look at the graph saying **EigenDA number
+ of processed batches**. This graph should be increasing like below graph: ![EigenDA correct sign](/img/operator-guides/avs-installation-and-registration/eigenda-operator-guide/eigenda-correct-sign.png)
 
-* If you have not setup metrics yet, you can still check the logs of your EigenDA Node. If your logs resemble like mentioned in [this section](./eigenda-avs-installation-registration-and-upgrade.md#step-5-run-eigenda) then you are signing correctly.
+* If you have not setup metrics yet, you can still check the logs of your
+  EigenDA Node. If your logs resemble like mentioned in [this
+  section](./eigenda-avs-installation-registration-and-upgrade.md#step-5-run-eigenda)
+  then you are signing correctly.
 
 #### My EigenDA node's logs look like these. What does it mean?
 
@@ -39,14 +46,22 @@ INFO [01-10|21:13:53.436|github.com/Layr-Labs/eigenda/node/node.go:233]         
 INFO [01-10|21:16:53.436|github.com/Layr-Labs/eigenda/node/node.go:233]             Complete an expiration cycle to remove expired batches "num expired batches found and removed"=0 caller=node.go:233
 ```
 
-This means you node software is running but you are not opted-in into EigenDA. If you opted in into EigenDA successfully and still not receiving dispersal traffic, make sure [your network settings allows](./eigenda-avs-installation-registration-and-upgrade.md#step-3-operator-networking-security-setup) EigenDA's disperser to reach your node.
+This means you node software is running but you are not opted-in into EigenDA.
+If you opted in into EigenDA successfully and still not receiving dispersal
+traffic, make sure [your network settings
+allows](./eigenda-avs-installation-registration-and-upgrade.md#step-3-operator-networking-security-setup)
+EigenDA's disperser to reach your node.
 
-If you were previously opted-in and was signing, it's possible you are [churned out](./overview.md#eigenda-churn-approver) by an other operator or you have been [ejected due to non-signing](./ejection-non-signing.md). Please try opting-in again.
+If you were previously opted-in and was signing, it's possible you are [churned
+out](./overview.md#eigenda-churn-approver) by an other operator or you have been
+[ejected due to non-signing](./ejection-non-signing.md). Please try opting-in
+again.
 
 #### I have a static load balancer in front of EigenDA node, how do I register and fix this IP for EigenDA?
 
 If you are running on k8s or have a load balancer in front of your EigenDA node
-and you don't want EigenDA to automatically update IP which is sent to EigenDA while registeration then follow the steps to make sure correct IP is registered
+and you don't want EigenDA to automatically update IP which is sent to EigenDA
+while registeration then follow the steps to make sure correct IP is registered
 
 * Update the [NODE_HOSTNAME](https://github.com/Layr-Labs/eigenda-operator-setup/blob/2872d76b5e0b127400eb7e6dd16da362c7c142ba/.env.example#L63) to the public IP where you will want to recieve traffic.
 * Opt-in using the provided [steps](./eigenda-avs-installation-registration-and-upgrade.md#step-4-opt-in-into-eigenda)

--- a/docs/eigenda/operator-guides/overview.md
+++ b/docs/eigenda/operator-guides/overview.md
@@ -5,13 +5,21 @@ sidebar_position: 1
 
 ## Introduction
 
-This guide contains the steps needed to set up your node on the EigenDA testnet. The testnet is used to test the operational and performance requirements for running a node before deploying on mainnet. The testnet is under constant stress tests and has frequent updates to the node software and other network components. It’s important to check regularly for new updates to the software and documentation.
+This guide contains the steps needed to set up your node on the EigenDA testnet.
+The testnet is used to test the operational and performance requirements for
+running a node before deploying on mainnet. The testnet is under constant stress
+tests and has frequent updates to the node software and other network
+components. It’s important to check regularly for new updates to the software
+and documentation.
 
 ## Operator System Requirements
 
 ### Node Classes
 
-Operators can determine their required [EigenLayer node class](/eigenlayer/operator-guides/avs-installation-and-registration/eigenlayer-node-classes.md) by referencing their share of the total EigenDA quorum against the following table.
+Operators can determine their required [EigenLayer node
+class](/eigenlayer/operator-guides/avs-installation-and-registration/eigenlayer-node-classes.md)
+by referencing their share of the total EigenDA quorum against the following
+table.
 
 |                         | Supported Throughput | Max % of Stake      |
 | ----------------------- | -------------------- | ------------------- |
@@ -19,15 +27,20 @@ Operators can determine their required [EigenLayer node class](/eigenlayer/opera
 | General Purpose - xl    | 500 Kbps             | 0.2%                |
 | General Purpose - 4xl   | 50 Mbps              | 20%                 |
 
-Professional operators with large or variable amounts of delegated stake should select the `4xl` node class. The `large` class is intended to be used by solo stakers with the minimal allowed quantity of stake.
+Professional operators with large or variable amounts of delegated stake should
+select the `4xl` node class. The `large` class is intended to be used by solo
+stakers with the minimal allowed quantity of stake.
 
-We will update this specification to include new EigenLayer node classes as they are introduced.
+We will update this specification to include new EigenLayer node classes as they
+are introduced.
 
 ### Node Storage Requirements
 
-EigenDA nodes must provision storage capacity (high performance SSD volumes) in order to store and serve all data passed to the node over a 2-week period.
+EigenDA nodes must provision storage capacity (high performance SSD volumes) in
+order to store and serve all data passed to the node over a 2-week period.
 
-The following table summarizes the amount of storage that is required for a node based on the amount of stake delegated to the operator.
+The following table summarizes the amount of storage that is required for a node
+based on the amount of stake delegated to the operator.
 
 | % of stake | Allocated Throughout | Required Storage |
 | ---------- | -------------------- | ---------------- |
@@ -38,31 +51,50 @@ The following table summarizes the amount of storage that is required for a node
 
 ## EigenDA Churn Approver
 
-The Churn Approver is responsible for managing the active set of Operator nodes in the EigenDA network. EigenDA uses an operator cap that limits the maximum number of active Operator nodes in the network in order to maintain the desired network performance and limit the L1 gas cost for aggregating signatures.
+The Churn Approver is responsible for managing the active set of Operator nodes
+in the EigenDA network. EigenDA uses an operator cap that limits the maximum
+number of active Operator nodes in the network in order to maintain the desired
+network performance and limit the L1 gas cost for aggregating signatures.
 
-:::info
-Active Operator Set Cap: the active operator set cap is currently limited to 200 operators. We will review this operator cap on an ongoing basis, and explicitly communicate future changes.
-:::
+:::info Active Operator Set Cap: the active operator set cap is currently
+limited to 200 operators. We will review this operator cap on an ongoing basis,
+and explicitly communicate future changes.  :::
 
-In order to determine the current TVL of the top 200 operators, please visit our [AVS page](https://goerli.eigenlayer.xyz/avs/eigenda) and sort by `TVL Ascending.`Observe the first 200 operators listed and the amount of ETH TVL delegated to them.
+In order to determine the current TVL of the top 200 operators, please visit our
+[AVS page](https://goerli.eigenlayer.xyz/avs/eigenda) and sort by `TVL
+Ascending.`Observe the first 200 operators listed and the amount of ETH TVL
+delegated to them.
 
-When a new operator wants to opt-in but EigenDA has reached its operator cap, the newly-registering operator can request a signature from the Churn Approver. The Churn Approver will check that the newly-joining operator meets stake requirements, and provide a signature that approves removing the current lowest-stake existing operator. The operator will then opt-in to EigenDA, providing the churner’s signature and information on the lowest-stake existing operator as additional inputs to EigenDA’s smart contract. Finally, the smart contract will:
+When a new operator wants to opt-in but EigenDA has reached its operator cap,
+the newly-registering operator can request a signature from the Churn Approver.
+The Churn Approver will check that the newly-joining operator meets stake
+requirements, and provide a signature that approves removing the current
+lowest-stake existing operator. The operator will then opt-in to EigenDA,
+providing the churner’s signature and information on the lowest-stake existing
+operator as additional inputs to EigenDA’s smart contract. Finally, the smart
+contract will:
 
 1. Check the Churn Approver’s signature.
-2. Perform checks against the stake of the newly-joining and (to-be-ejected) current lowest-stake operator:
-   - The new operator needs at least 1.1x the ejected operator’s stake.
-   - The ejected operator must constitute less than 3.33% of the total stake.
+2. Perform checks against the stake of the newly-joining and (to-be-ejected)
+current lowest-stake operator:
+    - The new operator needs at least 1.1x the ejected operator’s stake.
+    - The ejected operator must constitute less than 3.33% of the total stake.
 3. Eject the current lowest-stake operator.
 4. Proceed with opting-in the new operator, as normal.
 
-The parameters of checks performed in step 2 are configurable by the contract governance.
+The parameters of checks performed in step 2 are configurable by the contract
+governance.
 
 ### **Operator Ejection Confirmation**
 
 Operators that have been ejected can verify the change in two ways:
 
-1. Visit the EigenDA AVS application to observe whether your Operator is present in the active operator set on the [AVS page](https://goerli.eigenlayer.xyz/avs/eigenda).
-2. Observe your EigenDA Operator log for the following logs. If you see this consistently, then your operator is not receiving any disperser traffic and you may have been ejected. This is not an error but if you only see this log line repeatedly then it means you may not be receiving any disperser traffic.
+1. Visit the EigenDA AVS application to observe whether your Operator is present
+in the active operator set on the [AVS page](https://goerli.eigenlayer.xyz/avs/eigenda).
+2. Observe your EigenDA Operator log for the following logs. If you see this
+consistently, then your operator is not receiving any disperser traffic and you
+may have been ejected.  This is not an error but if you only see this log line
+repeatedly then it means you may not be receiving any disperser traffic.
 
 ```
 INFO [12-21|18:53:46.673|github.com/Layr-Labs/eigenda/node/node.go:233]             Complete an expiration cycle to remove expired batches "num expired batches found and removed"=3  caller=node.go:233

--- a/docs/eigenda/operator-guides/troubleshooting.md
+++ b/docs/eigenda/operator-guides/troubleshooting.md
@@ -12,8 +12,12 @@ sidebar_position: 6
 Error: failed to opt-in EigenDA Node Network for operator ID: <OPERATOR_ID>, operator address: <OPERATOR_ADDRESS>, error: failed to request churn approval: rpc error: code = Unknown desc = failed to process churn request: registering operator must have 10.000000% more than the stake of the lowest-stake operator. Stake of registering operator: 0, stake of lowest-stake operator: 6301801525718228411481, quorum ID: 0
 ```
 
-This is because your operator doesn't have enough stake to run EigenDA. Please refer to [this](./overview.md#eigenda-churn-approver) to learn more about this error
+This is because your operator doesn't have enough stake to run EigenDA. Please
+refer to [this](./overview.md#eigenda-churn-approver) to learn more about this
+error
 
 #### failed to read or decrypt the BLS/ECDSA private key
 
-Please make sure the operator keys [location in the .env file](https://github.com/Layr-Labs/eigenda-operator-setup/blob/19c386e38a838e28be27bd2737252d3fe2ce8a62/.env#L83) is correctly populated. Make sure to put correct bls and ecdsa key location
+Please make sure the operator keys [location in the .env
+file](https://github.com/Layr-Labs/eigenda-operator-setup/blob/19c386e38a838e28be27bd2737252d3fe2ce8a62/.env#L83)
+is correctly populated. Make sure to put correct bls and ecdsa key location

--- a/docs/eigenda/rollup-guides/README.md
+++ b/docs/eigenda/rollup-guides/README.md
@@ -1,0 +1,13 @@
+# Rollup Guides
+
+This section contains specs, guides and examples for integrating rollups with EigenDA.
+
+<!-- Data Availability is a requirement for both for ZK and Optimistic rollups
+([source](http://datalayr-docs.s3-website-us-east-1.amazonaws.com/build/rollups/)):
+
+* In both optimistic rollups and ZK-rollups, if transaction data is not
+available, then participants in the rollup will be unable to reconstruct the
+rollup state so as to bridge out their assets if desired.
+* In optimistic rollups, if transaction data is not available, challengers are
+* unable to check
+the sequencer’s state commitment and create fraud proofs when applicable. -->

--- a/docs/eigenda/rollup-guides/op-stack/README.md
+++ b/docs/eigenda/rollup-guides/op-stack/README.md
@@ -5,51 +5,110 @@ title: OP Stack
 
 ## OP Stack and EigenDA
 
-[OP Stack](https://stack.optimism.io/) is the set of [software components](https://github.com/ethereum-optimism/optimism) that run sequencers, nodes and contracts for [Optimism](https://www.optimism.io/) and which can be independently deployed to power third-party rollups.
+[OP Stack](https://stack.optimism.io/) is the set of [software
+components](https://github.com/ethereum-optimism/optimism) that run sequencers,
+nodes and contracts for [Optimism](https://www.optimism.io/) and which can be
+independently deployed to power third-party rollups.
 
-In its native mode, OP Stack uses Ethereum for Data Availability, meaning it persists L2 transaction batches to Ethereum in the form of calldata to form the canonical L2 chain. This comes with advantages and disadvantages. The advantage of using Ethereum for DA is that the data is fully secured by Ethereum's security budget, and the system is relatively simple. The drawback is that Ethereum calldata is expensive, and relatively scarce. Ethereum's consensus throughput (pre-EIP-4844) is 200Kb per block, every 12 seconds. That is not enough to scale the decentralized web. **When execution throughput was the main bottleneck to scaling Ethereum, rollups were the answer. Now DA throughput has become the bottleneck to scaling rollups, and the answer is EigenDA.** Write L2 transaction data to a permissionless, trustless, secure, and scalable DA Operator set, and the last bottleneck on the performance of your rollup will be removed.
+In its native mode, OP Stack uses Ethereum for Data Availability, meaning it
+persists L2 transaction batches to Ethereum in the form of calldata to form the
+canonical L2 chain. This comes with advantages and disadvantages. The advantage
+of using Ethereum for DA is that the data is fully secured by Ethereum's
+security budget, and the system is relatively simple. The drawback is that
+Ethereum calldata is expensive, and relatively scarce. Ethereum's consensus
+throughput (pre-EIP-4844) is 200Kb per block, every 12 seconds. That is not
+enough to scale the decentralized web. **When execution throughput was the main
+bottleneck to scaling Ethereum, rollups were the answer. Now DA throughput has
+become the bottleneck to scaling rollups, and the answer is EigenDA.** Write L2
+transaction data to a permissionless, trustless, secure, and scalable DA
+Operator set, and the last bottleneck on the performance of your rollup will be
+removed.
 
-[**EigenLabs has forked OP Stack**](https://github.com/Layr-labs/optimism) **to add optional support for EigenDA. The modifications were relatively simple and are detailed in the next section.**
+[**EigenLabs has forked OP Stack**](https://github.com/Layr-labs/optimism) **to
+add optional support for EigenDA. The modifications were relatively simple and
+are detailed in the next section.**
 
 ## How it works
 
 ![OP stack digram](/img/op-stack-blob-disersal-seq.png)
 
-In the absence of fraud proofs, the integration is relatively simple. On the sequencing side instead of writing L2 transaction data to Ethereum calldata, we write L2 transaction data to EigenDA. Then we take the resulting EigenDA blob key and write that to Ethereum calldata. Where the blob data could be many megabytes in size, the blob key is only a few bytes long and so the cost of the calldata becomes relatively negligible.
+In the absence of fraud proofs, the integration is relatively simple. On the
+sequencing side instead of writing L2 transaction data to Ethereum calldata, we
+write L2 transaction data to EigenDA. Then we take the resulting EigenDA blob
+key and write that to Ethereum calldata. Where the blob data could be many
+megabytes in size, the blob key is only a few bytes long and so the cost of the
+calldata becomes relatively negligible.
 
-The other side of the integration is the L2 derivation pipeline, which both sequencers and nodes run continuously to keep track of the canonical L2 chain state. We updated this process to recognize EigenDA blob keys posted to the L2 inbox, so that we know to download that data from EigenDA before continuing derivation.
+The other side of the integration is the L2 derivation pipeline, which both
+sequencers and nodes run continuously to keep track of the canonical L2 chain
+state. We updated this process to recognize EigenDA blob keys posted to the L2
+inbox, so that we know to download that data from EigenDA before continuing
+derivation.
 
-One salient feature of this integration is a safety mechanism for falling back to Ethereum DA in the event that EigenDA is not functioning correctly.
+One salient feature of this integration is a safety mechanism for falling back
+to Ethereum DA in the event that EigenDA is not functioning correctly.
 
 ## L1 Contracts
 
-No contract changes are required for this integration. The latest OP Stack release [Bedrock](https://stack.optimism.io/docs/releases/bedrock/) includes contracts that implement the integration between the L1 and L2, and integration points between the Sequencer and the L1. Although EigenDA supports on-chain data availability verification, the current version of OP Stack has not yet fully integrated support for fault proofs (more detail [here on their Alpha release](https://blog.oplabs.co/op-stack-fault-proof-alpha/)). We plan to enable this verification with EigenLayer once OP Stack has fully integrated their fault-proof architecture.
+No contract changes are required for this integration. The latest OP Stack
+release [Bedrock](https://stack.optimism.io/docs/releases/bedrock/) includes
+contracts that implement the integration between the L1 and L2, and integration
+points between the Sequencer and the L1. Although EigenDA supports on-chain data
+availability verification, the current version of OP Stack has not yet fully
+integrated support for fault proofs (more detail [here on their Alpha
+release](https://blog.oplabs.co/op-stack-fault-proof-alpha/)). We plan to enable
+this verification with EigenLayer once OP Stack has fully integrated their
+fault-proof architecture.
 
 ## Sequencer
 
-The OP Stack Sequencer consists of 4 independent processes (long running services):
+The OP Stack Sequencer consists of 4 independent processes (long running
+services):
 
-- **Op-node**: Primarily responsible for producing new L2 blocks with the help of Op-geth, a necessary part of this is tracking L2 consensus on the L1.
+- **Op-node**: Primarily responsible for producing new L2 blocks with the help
+of Op-geth, a necessary part of this is tracking L2 consensus on the L1.
 - **Op-geth**: Responsible for the L2 state and its state machine API.
 - **Op-batcher**: Responsible for posting new L2 blocks to DA.
-- **Op-proposer**: Responsible for posting state roots associated with L2 blocks to settlement.
+- **Op-proposer**:
+Responsible for posting state roots associated with L2 blocks to settlement.
 
 To add EigenDA support to the OP Stack Sequencer, we need to:
 
-1. **Update DA writes**: modify how L2 transaction data is posted for DA (Op-batcher).
-2. **Update DA reads**: modify how L2 transaction data is [derived](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#l2-chain-derivation-pipeline) from DA (op-node).
+1. **Update DA writes**: modify how L2 transaction data is posted for DA
+(Op-batcher).
+2. **Update DA reads**: modify how L2 transaction data is
+[derived](https://github.com/ethereum-optimism/optimism/blob/develop/specs/derivation.md#l2-chain-derivation-pipeline)
+from DA (op-node).
 
-The Op-batcher service is modified to write (disperse) its Optimism [data frame](https://github.com/ethereum-optimism/optimism/blob/develop/specs/glossary.md#channel-frame) (a grouping of L2 transactions) to EigenDA, wait for confirmation and the resulting BlobInfo object. If the EigenDA dispersal is successful, the Op-batcher writes the BlobInfo object to Ethereum calldata instead of its original data frame. If the EigenDA dispersal fails, the Op-batcher service writes the original Optimism data frame to Ethereum calldata.
+The Op-batcher service is modified to write (disperse) its Optimism [data
+frame](https://github.com/ethereum-optimism/optimism/blob/develop/specs/glossary.md#channel-frame)
+(a grouping of L2 transactions) to EigenDA, wait for confirmation and the
+resulting BlobInfo object. If the EigenDA dispersal is successful, the
+Op-batcher writes the BlobInfo object to Ethereum calldata instead of its
+original data frame. If the EigenDA dispersal fails, the Op-batcher service
+writes the original Optimism data frame to Ethereum calldata.
 
-DA reads occur in the Op-node service, as part of the L2 derivation pipeline, where L2 transaction batches are “derived” from DA. The logic in this service is modified to determine whether the calldata contains a BlobInfo object (the result from the EigenDA dispersal step above) and retrieve its data from EigenDA, otherwise follow its normal derivation path from the data frame. In the future we expect to enhance this client to handle more robust EigenDA features, such as quorum selection for retrieval.
+DA reads occur in the Op-node service, as part of the L2 derivation pipeline,
+where L2 transaction batches are “derived” from DA. The logic in this service is
+modified to determine whether the calldata contains a BlobInfo object (the
+result from the EigenDA dispersal step above) and retrieve its data from
+EigenDA, otherwise follow its normal derivation path from the data frame. In the
+future we expect to enhance this client to handle more robust EigenDA features,
+such as quorum selection for retrieval.
 
 ## Resources
 
-- Eigen Labs OP Stack Fork: [https://github.com/Layr-Labs/optimism](https://github.com/Layr-Labs/optimism)
-- Announcing EigenDA x OP Stack Support: [https://www.blog.eigenlayer.xyz/announcing-eigenda-x-op-stack-support/](https://www.blog.eigenlayer.xyz/announcing-eigenda-x-op-stack-support/)
+- Eigen Labs OP Stack Fork:
+[https://github.com/Layr-Labs/optimism](https://github.com/Layr-Labs/optimism) -
+Announcing EigenDA x OP Stack Support:
+[https://www.blog.eigenlayer.xyz/announcing-eigenda-x-op-stack-support/](https://www.blog.eigenlayer.xyz/announcing-eigenda-x-op-stack-support/)
 
 ## Next Steps
 
-If you are a Rollup considering integrating with EigenDA and OP Stack - reach out to our team to discuss how we can support and accelerate your onboarding: [https://contact.eigenda.xyz/](https://contact.eigenda.xyz/)
+If you are a Rollup considering integrating with EigenDA and OP Stack - reach
+out to our team to discuss how we can support and accelerate your onboarding:
+[https://contact.eigenda.xyz/](https://contact.eigenda.xyz/)
 
-If you are a Rollup developer and have questions on the integration- reach out to our Support team via: [https://support.eigenlayer.xyz/](https://support.eigenlayer.xyz/)
+If you are a Rollup developer and have questions on the integration- reach out
+to our Support team via:
+[https://support.eigenlayer.xyz/](https://support.eigenlayer.xyz/)

--- a/docs/eigenda/rollup-guides/op-stack/deploying-op-stack-+-eigenda-locally.md
+++ b/docs/eigenda/rollup-guides/op-stack/deploying-op-stack-+-eigenda-locally.md
@@ -4,7 +4,8 @@ title: Local Deployment
 
 # Deploying EigenDA OP Stack Locally
 
-This guide will show you how to deploy an OP Stack rollup on a local Ethereum instance, using a local EigenDA instance for DA.
+This guide will show you how to deploy an OP Stack rollup on a local Ethereum
+instance, using a local EigenDA instance for DA.
 
 ## Preparations
 
@@ -16,43 +17,38 @@ Hardware:
 
 Software:
 
-* Docker runtime
-* Unix OS: Linux or MacOS
+* Docker runtime Unix OS: Linux or MacOS
 
 ### Installing Dependencies
 
-1. Install [foundry](https://book.getfoundry.sh/getting-started/installation) (general version)
+1. Install [foundry](https://book.getfoundry.sh/getting-started/installation)
+(general version)
 2. Install [gvm](https://github.com/moovweb/gvm)
 3. Install [localstack](https://localstack.cloud/)
-4. Install [protobuf compiler](https://grpc.io/docs/protoc-installation/)
+4. Install [protobuf
+compiler](https://grpc.io/docs/protoc-installation/)
 5. Install [graph-cli](https://www.npmjs.com/package/@graphprotocol/graph-cli)
 
 ## Running EigenDA Locally
 
 ```
-# clone and init
-# this branch runs EigenDA against an L1 instance on port 8547 instead of 8545,
-# so as not to conflict with Optimism's local L1 instance.
-git clone -b opstack-poc git@github.com:Layr-Labs/eigenda.git
-cd eigenda
-git submodule update --init --recursive
+# clone and init this branch runs EigenDA against an L1 instance on port 8547
+# instead of 8545, so as not to conflict with Optimism's local L1 instance.
+git clone -b opstack-poc git@github.com:Layr-Labs/eigenda.git cd eigenda git
+submodule update --init --recursive
 
 # install and use correct golang version
-gvm install $(cat .go-version)
-gvm use $(cat .go-version)
+gvm install $(cat .go-version) gvm use $(cat .go-version)
 
 # build
 make build
 
 # start local environment
-cd inabox
-make clean new-anvil deploy-all
-./bin.sh start
+cd inabox make clean new-anvil deploy-all ./bin.sh start
 
 # Congrats! EigenDA is running
 
-# To clean up
-# Ctrl+C to quit EigenDA
+# To clean up Ctrl+C to quit EigenDA
 
 # then to stop anvil, the graph and localstack
 make stop-infra 
@@ -61,26 +57,33 @@ make stop-infra
 ## Running OpStack Locally
 
 ```
+
 # clone
-git clone -b eigenda-develop git@github.com:Layr-Labs/optimism.git
-cd optimism
+
+git clone -b eigenda-develop <git@github.com>:Layr-Labs/optimism.git cd optimism
 git submodule update --init --recursive
 
 # install and use correct golang version
-gvm intall $(cat .go-version)
-gvm use $(cat .go-version)
+
+gvm intall $(cat .go-version) gvm use $(cat .go-version)
 
 # build correct foundry version from source (may take a few minutes)
+
 foundryup -C $(cat .foundryrc)
 
 # start OP Stack devnet
+
 make devnet-up
 
-# Congrats, you're running OpStack against EigenDA!
+# Congrats, you're running OpStack against EigenDA
 
-# I like to use Docker Desktop for looking at container logs. You can click into the OpStack "batcher" and "node" containers to see the logs, and then ctrl+F for "EigenDA" to see relevant events.
+# I like to use Docker Desktop for looking at container logs. You can click into
+
+# the OpStack "batcher" and "node" containers to see the logs, and then ctrl+F
+
+# for "EigenDA" to see relevant events
 
 # to clean up (also useful to try in the case of unexpected errors)
-make devnet-down devnet-clean
 
+make devnet-down devnet-clean
 ```

--- a/docs/eigenda/rollup-guides/orbit/README.md
+++ b/docs/eigenda/rollup-guides/orbit/README.md
@@ -1,15 +1,37 @@
 # Arbitrum Orbit User Guide
 
-[Arbitrum Orbit](https://docs.arbitrum.io/launch-orbit-chain/orbit-gentle-introduction) is a Rollup Development Kit (RDK) developed by [Offchain Labs](https://www.offchainlabs.com/) to enable rollup developers to build rollups using the same software that powers *Arbitrum One* and *Arbitrum Nova*. In partnership with AltLayer, we have forked the core component of Orbit, [Nitro](https://github.com/layr-Labs/nitro), to add [M0](../../integrations-overview.md#M0) support for EigenDA. The M0 status of this integration means that it is only designed for testnet.
+[Arbitrum
+Orbit](https://docs.arbitrum.io/launch-orbit-chain/orbit-gentle-introduction) is
+a Rollup Development Kit (RDK) developed by [Offchain
+Labs](https://www.offchainlabs.com/) to enable rollup developers to build
+rollups using the same software that powers *Arbitrum One* and *Arbitrum Nova*.
+In partnership with AltLayer, we have forked the core component of Orbit,
+[Nitro](https://github.com/layr-Labs/nitro), to add
+[M0](../../integrations-overview.md#M0) support for EigenDA. The M0 status of
+this integration means that it is only designed for testnet.
 
 ## How to deploy an Orbit chain
 
 A short guide on launching an Orbit L3 against the EigenDA testnet:
 
-Follow the [Orbit Quickstart](https://docs.arbitrum.io/launch-orbit-chain/orbit-quickstart) documentation until step 9, skipping step 7. When prompted to use the official [orbit-setup-script repo](https://github.com/OffchainLabs/orbit-setup-script), use the [forked repo](https://github.com/Layr-Labs/orbit-setup-script) instead. At the end of step 8 you should have your `chainConfig.json` and `orbitSetupScriptConfig.json` saved locally.
+Follow the [Orbit
+Quickstart](https://docs.arbitrum.io/launch-orbit-chain/orbit-quickstart)
+documentation until step 9, skipping step 7. When prompted to use the official
+[orbit-setup-script repo](https://github.com/OffchainLabs/orbit-setup-script),
+use the [forked repo](https://github.com/Layr-Labs/orbit-setup-script) instead.
+At the end of step 8 you should have your `chainConfig.json` and
+`orbitSetupScriptConfig.json` saved locally.
 
-This fork of Nitro is on version v2.2.0, but the *Orbit chain deployment portal* is on version v2.1.3, which means the `nodeConfig.json` must be updated to reflect the new format, according to the configuration migration guide in the [v2.2.0 release notes](https://github.com/OffchainLabs/nitro/releases/tag/v2.2.0).
+This fork of Nitro is on version v2.2.0, but the *Orbit chain deployment portal*
+is on version v2.1.3, which means the `nodeConfig.json` must be updated to
+reflect the new format, according to the configuration migration guide in the
+[v2.2.0 release
+notes](https://github.com/OffchainLabs/nitro/releases/tag/v2.2.0).
 
-Finally, continue with steps 9-11 with your updated configuration file. If you've completed these steps successfully, congrats! You are now running an Orbit rollup that uses EigenDA.
+Finally, continue with steps 9-11 with your updated configuration file. If
+you've completed these steps successfully, congrats! You are now running an
+Orbit rollup that uses EigenDA.
 
-This documentation is under construction and will continue to change. For technical questions and hand-on support please reach out to [contact.eigenda.xyz](https://contact.eigenda.xyz).
+This documentation is under construction and will continue to change. For
+technical questions and hand-on support please reach out to
+[contact.eigenda.xyz](https://contact.eigenda.xyz).

--- a/docs/eigenda/rollup-guides/tutorial.md
+++ b/docs/eigenda/rollup-guides/tutorial.md
@@ -4,15 +4,28 @@ sidebar_position: 1
 
 # Dispersing your first blob
 
-Rollup developers must plan for two points of integration with EigenDA: off chain integration with their sequencer and on-chain integration with their rollup smart contracts. Off chain integration involves a series of RPC calls to the EigenDA Disperser. On chain integration involves a smart contract function call to verify the blob was stored in the EigenDA network.
+Rollup developers must plan for at least two points of integration with EigenDA: offchain
+integration with their sequencer and onchain integration with their rollup smart
+contracts. The offchain integration involves a series of RPC calls to the
+EigenDA disperser as part of the transaction batching process. The onchain
+integration involves a smart contract function call to verify the blob was
+stored in the EigenDA network, as well as updates to how.
 
-These instructions are built to interact with the live EigenDA testnet. For developers who wish to operate a local network for testing and debugging, please see the instructions in the [EigenDA inabox tests here](https://github.com/Layr-Labs/eigenda/tree/master/inabox).
+These instructions are built to interact with the live EigenDA testnet. For
+developers who wish to operate a local network for testing and debugging, please
+see the instructions in the [EigenDA inabox tests
+here](https://github.com/Layr-Labs/eigenda/tree/master/inabox).
 
 ## Off-Chain: Configure Your Sequencer Backend Service
 
-The EigenDA service is built as a [gRPC service](https://grpc.io/). There are many available clients you may use for your integration. For the following examples we leverage [grpcurl](https://github.com/fullstorydev/grpcurl), however please see [Awesome gRPC](https://github.com/grpc-ecosystem/awesome-grpc#tools) for a complete list to choose the best client for your project.
+EigenDA is built as a [gRPC service](https://grpc.io/). There are
+many available clients you may use for your integration. For the following
+examples we leverage [grpcurl](https://github.com/fullstorydev/grpcurl), however
+please see [Awesome gRPC](https://github.com/grpc-ecosystem/awesome-grpc#tools)
+for a complete list to choose the best client for your project.
 
-Please find the complete EigenDA API documentation in the [EigenDA github repo here](https://github.com/Layr-Labs/eigenda/tree/master/api/docs).
+Please find the complete EigenDA API documentation in the [EigenDA github repo
+here](https://github.com/Layr-Labs/eigenda/tree/master/api/docs).
 
 ### Disperse and Retrieve Blob Examples
 
@@ -20,88 +33,132 @@ Please find the complete EigenDA API documentation in the [EigenDA github repo h
 
 - Open a linux terminal.
 - [Install grpccurl for your environment](https://github.com/fullstorydev/grpcurl#installation).
-- Download the eigenda repository and change your current working directory. The included Protobuf definitions will be required:
+- Download the eigenda repository and change your current working directory. The
+included Protobuf definitions will be required:
 
-```
-gh repo clone Layr-Labs/eigenda
-cd eigenda
-```
+``` gh repo clone Layr-Labs/eigenda cd eigenda ```
 
 **Step 1: Store (Disperse) a blob**
 
-Invooke the Disperser/DisperseBlob endpoint.
+Invoke the Disperser/DisperseBlob endpoint.
 
 Example request:
 
 ```
 # Download the EigenDA repo via gh client or wget
 gh repo clone Layr-Labs/eigenda
-# Change your working directory to the eigenda folder in order to point to the protobuf defintions correctly
+# Change your working directory to the eigenda folder in order to point to the
+# protobuf defintions correctly
 cd eigenda
 
-grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d '{"data": "0000", "security_params": [{"quorum_id": 0, "adversary_threshold": 25, "quorum_threshold": 50}]}' disperser-goerli.eigenda.xyz:443 disperser.Disperser/DisperseBlob
+grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d
+'{"data": "0000", "security_params": [{"quorum_id": 0, "adversary_threshold":
+25, "quorum_threshold": 50}]}' disperser-goerli.eigenda.xyz:443
+disperser.Disperser/DisperseBlob
 
 ```
 
 **Step 2: Validate the blob was stored in a batch**
 
-Invoke the Disperser/GetBlobStatus service in order to validate the blob was correctly stored and dispersed to the EigenDA network. The GetBlobStatus service will return a value via the BlobStatus enumerated type.
+Invoke the Disperser/GetBlobStatus service in order to validate the blob was
+correctly stored and dispersed to the EigenDA network. The GetBlobStatus service
+will return a value via the BlobStatus enumerated type.
 
-Best practice is for users to poll the GetBlobStatus service to monitor status of the Blobs as needed. Rollups may Polling once every 5-10 seconds to monitor the status of a blob until it has successfully dispersed on the network with status of CONFIRMED. Confirmation can take up to a few minutes after the blob has been initially sent to the disperser, depending on network conditions.
+Best practice is for users to poll the GetBlobStatus service to monitor status
+of the Blobs as needed. Rollups may Polling once every 5-10 seconds to monitor
+the status of a blob until it has successfully dispersed on the network with
+status of CONFIRMED. Confirmation can take up to a few minutes after the blob
+has been initially sent to the disperser, depending on network conditions.
 
 Example request:
 
 ```
-# Update the value of INSERT_REQUEST_ID with the result of your disperse call above
+# Update the value of INSERT_REQUEST_ID with the result of your disperse call
+# above
 
-grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d '{"request_id": "INSERT_REQUEST_ID"}' disperser-goerli.eigenda.xyz:443 disperser.Disperser/GetBlobStatus
+grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d
+'{"request_id": "INSERT_REQUEST_ID"}' disperser-goerli.eigenda.xyz:443
+disperser.Disperser/GetBlobStatus
 ```
 
 **Step 3: Retrieve a blob**
 
-Option A: invoke the Disperser/RetrieveBlob rpc endpoint. This is a recommended function for anyone that would like to inspect a stored blob.
+Option A: invoke the Disperser/RetrieveBlob rpc endpoint. This is a recommended
+function for anyone that would like to inspect a stored blob.
 
 Example request:
 
 ```
-# Note the value for batch_header_hash
-Can be obtained from the result of your call to GetBlobStatus via info.blob_verification_proof.batch_metadata.batch_header_hash.
 
+# Note the value for batch_header_hash can be obtained from the result of your
+# call to GetBlobStatus via info.blob_verification_proof.batch_metadata.batch_header_hash.
 
 grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d '{"batch_header_hash": "INSERT_VALUE", "blob_index":"INSERT_VALUE"}' disperser-goerli.eigenda.xyz:443 disperser.Disperser/RetrieveBlob
 ```
 
-Option B: Retrieve the blob directly from EigenDA nodes. Integrate the [Retrieval Client](https://github.com/Layr-Labs/eigenda/blob/master/clients/retrieval_client.go) into your Go binary.
+Option B: Retrieve the blob directly from EigenDA nodes. Integrate the
+[Retrieval
+Client](https://github.com/Layr-Labs/eigenda/blob/master/clients/retrieval_client.go)
+into your Go binary.
 
 ### Null Bytes Padding
 
-When the blob is retrieved it may be appended by a number of null bytes, which the caller will need to remove. This occurs because the Disperser pads the blob with null bytes to fit the frame size for encoding.
+When the blob is retrieved it may be appended by a number of null bytes, which
+the caller will need to remove. This occurs because the Disperser pads the blob
+with null bytes to fit the frame size for encoding.
 
-Once the user decodes the data, the decoded data may have null bytes appended to the end. [Here is an example](https://github.com/Layr-Labs/eigenda/blob/master/test/integration_test.go#L522) on how we trim the appended null bytes from recovered data.
+Once the user decodes the data, the decoded data may have null bytes appended to
+the end. [Here is an example](https://github.com/Layr-Labs/eigenda/blob/master/test/integration_test.go#L522)
+on how we trim the appended null bytes from recovered data.
 
 ## On-Chain: Configure Your Sequencer Smart Contracts
 
-Data Availability is a requirement for both for ZK and Optimistic rollups ([source](http://datalayr-docs.s3-website-us-east-1.amazonaws.com/build/rollups/)):
+Data Availability is a requirement for both for ZK and Optimistic rollups
+([source](http://datalayr-docs.s3-website-us-east-1.amazonaws.com/build/rollups/)):
 
-- In both optimistic rollups and ZK-rollups, if transaction data is not available, then participants in the rollup will be unable to reconstruct the rollup state so as to bridge out their assets if desired.
-- In optimistic rollups, if transaction data is not available, challengers are unable to check the sequencer’s state commitment and create fraud proofs when applicable.
+- In both optimistic rollups and ZK-rollups, if transaction data is not
+available, then participants in the rollup will be unable to reconstruct the
+rollup state so as to bridge out their assets if desired.  - In optimistic
+rollups, if transaction data is not available, challengers are unable to check
+the sequencer’s state commitment and create fraud proofs when applicable.
 
 **Verifying Blob Availability On Chain**
 
-verifyBlob() is the primary function that needs to be invoked by the rollup smart contracts. This function will take the blobHeader and blobVerificationProof as inputs and execute a series of checks to ensure the blob was signed for and stored properly in the EigenDA network.
+verifyBlob() is the primary function that needs to be invoked by the rollup
+smart contracts. This function will take the blobHeader and
+blobVerificationProof as inputs and execute a series of checks to ensure the
+blob was signed for and stored properly in the EigenDA network.
 
-Each rollup can determine how often they will invoke this function and under which conditions. This may be invoked via the sequencer, validator or other component in the rollup architecture.
+Each rollup can determine how often they will invoke this function and under
+which conditions. This may be invoked via the sequencer, validator or other
+component in the rollup architecture.
 
-1. Import the [EigenDABlobUtils.sol](https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/libraries/EigenDABlobUtils.sol) file to your rollup’s source code repository.
+1. Import the
+[EigenDABlobUtils.sol](https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/libraries/EigenDABlobUtils.sol)
+file to your rollup’s source code repository.
 2. Add the library to your rollup smart contract.
 3. Invoke the verifyBlob() function
 
-On-chain applications will receive the blob header and blob verification proof via the Rollup sequencer. This proof is returned during the confirmation phase when the blob is first written. It is the responsibility of the rollup sequencer to post a blob key extracted from this metadata on-chain, so that it might be verified to be available during a fault proof challenge.
+On-chain applications will receive the blob header and blob verification proof
+via the Rollup sequencer. This proof is returned during the confirmation phase
+when the blob is first written. It is the responsibility of the rollup sequencer
+to post a blob key extracted from this metadata on-chain, so that it might be
+verified to be available during a fault proof challenge.
 
 **Fraud Proving (Optional)**
 
-If a rollup wishes to implement their own fraud proof with EigenDA, we have provided an example via the [EigenDAKZGUtils.openCommitment()](https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/libraries/EigenDAKZGUtils.sol) function. Opening a commitment is the way to prove to the light client for the rollup (perhaps the rollup bridge smart contract) that a certain state transition is incorrect. It reveals the underlying data of the polynomial.
+If a rollup wishes to implement their own fraud proof with EigenDA, we have
+provided an example via the
+[EigenDAKZGUtils.openCommitment()](https://github.com/Layr-Labs/eigenda/blob/master/contracts/src/libraries/EigenDAKZGUtils.sol)
+function. Opening a commitment is the way to prove to the light client for the
+rollup (perhaps the rollup bridge smart contract) that a certain state
+transition is incorrect. It reveals the underlying data of the polynomial.
 
-Per [EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#how-rollups-would-function):
+Per
+[EIP-4844](https://eips.ethereum.org/EIPS/eip-4844#how-rollups-would-function):
 
-“The fraud proof can verify the transition in smaller steps, loading at most a few values of the blob at a time through calldata. For each value it would provide a KZG proof and use the point evaluation precompile to verify the value against the versioned hash that was submitted before, and then perform the fraud proof verification on that data as is done today.”
+“The fraud proof can verify the transition in smaller steps, loading at most a
+few values of the blob at a time through calldata. For each value it would
+provide a KZG proof and use the point evaluation precompile to verify the value
+against the versioned hash that was submitted before, and then perform the fraud
+proof verification on that data as is done today.”

--- a/docs/eigenda/system-performance-and-customization.md
+++ b/docs/eigenda/system-performance-and-customization.md
@@ -9,22 +9,38 @@ sidebar_position: 2
 EigenDA end to end latency is measured between the following times:
 
 - Store (Disperse) blob is written through the Disperser API.
-- Blob availability proof (via aggregate BLS signatures) is available to be verified on chain.
+- Blob availability proof (via aggregate BLS signatures) is available to be
+verified on chain.
 
-For the Stage 2 Testnet launch the maximum end to end latency is approximately 60 seconds.
+For the Stage 2 Testnet launch the maximum end to end latency is approximately
+60 seconds.
 
 ## Encoded System Throughput
 
-The total volume of raw data traffic that is distributed among the distributed set of EigenDA nodes is known as the Encoded System Throughput. Encoded system throughput is what puts burden on the system, so system performance limits are defined in terms of the encoded system throughput.
+The total volume of raw data traffic that is distributed among the distributed
+set of EigenDA nodes is known as the Encoded System Throughput. Encoded system
+throughput is what puts burden on the system, so system performance limits are
+defined in terms of the encoded system throughput.
 
-When a rollup sends a blob to the system, it specifies a Quorum Threshold and an Adversary Threshold. Together, these parameters determine how the data is encoded and in particular how much of the Encoded System Throughput the blob will consume.
+When a rollup sends a blob to the system, it specifies a Quorum Threshold and an
+Adversary Threshold. Together, these parameters determine how the data is
+encoded and in particular how much of the Encoded System Throughput the blob
+will consume.
 
-- Quorum Threshold is the minimum percentage of stake that must attest in order to consider the blob dispersal successful. As such, clients can use this setting to customize liveness requirements (a low Quorum Threshold means that a smaller set of operators can support a dispersal request, whereas a high Quorum Threshold quires more operators to be available to provide liveness).
-- Adversary Threshold is the maximum percentage of the stake which can be held by nodes acting in an adversarial manner before the availability of a blob is affected.
-- Based on chosen values for Adversary Threshold and Quorum Threshold, the Coding ratio is derived as follows:
+- Quorum Threshold is the minimum percentage of stake that must attest in order
+to consider the blob dispersal successful. As such, clients can use this setting
+to customize liveness requirements (a low Quorum Threshold means that a smaller
+set of operators can support a dispersal request, whereas a high Quorum
+Threshold quires more operators to be available to provide liveness).
+- Adversary Threshold is the maximum percentage of the stake which can be held by
+nodes acting in an adversarial manner before the availability of a blob is
+affected.
+- Based on chosen values for Adversary Threshold and Quorum
+Threshold, the Coding ratio is derived as follows:
   - Coding Ratio = 100 / (Quorum Threshold - Adversary Threshold)
 
-For testing purposes you can start with an Adversary Threshold of 33% and Quorum Threshold of 80%.
+For testing purposes you can start with an Adversary Threshold of 33% and Quorum
+Threshold of 80%.
 
 Additional performance characteristics for the Disperser:
 
@@ -34,9 +50,21 @@ Additional performance characteristics for the Disperser:
 
 ## Rate Limiting
 
-The EigenDA system will limit the rate that any individual Rollup user (e.g., sequencer) can post data. In the future, these rates will be determined via a system of reservation and on-demand payment. However, at the current testnet stage, the system enforces the following uniform rate limits for all users, as identified by the IP address of their request:
+The EigenDA system will limit the rate that any individual Rollup user (e.g.,
+sequencer) can post data. In the future, these rates will be determined via a
+system of reservation and on-demand payment. However, at the current testnet
+stage, the system enforces the following uniform rate limits for all users, as
+identified by the IP address of their request:
 
-- The maximum throughput for an individual Rollup user is approximately 3KiB/s encoded.
-- For a constant amount of data, the Disperser's KZG proving system more efficiently processes a small number of large blobs compared to a large number of small blobs. Thus, we also enforce a limit on the rate at which each rollup posts blobs to the system. Currently, rollups are limited to approximately one blob per batching interval (~100 seconds).
+- The maximum throughput for an individual Rollup user is approximately 3KiB/s
+encoded.
+- For a constant amount of data, the Disperser's KZG proving system
+more efficiently processes a small number of large blobs compared to a large
+number of small blobs. Thus, we also enforce a limit on the rate at which each
+rollup posts blobs to the system. Currently, rollups are limited to
+approximately one blob per batching interval (~100 seconds).
 
-Both of these rate limits are enforced over an interval of about 10 minutes. The user's request sent to the Disperser will be rate limited if their total throughput exceeds the above rate limits, and the user's request to DisperseBlob will return a rate limit error.
+Both of these rate limits are enforced over an interval of about 10 minutes. The
+user's request sent to the Disperser will be rate limited if their total
+throughput exceeds the above rate limits, and the user's request to DisperseBlob
+will return a rate limit error.


### PR DESCRIPTION
This change is purely cosmetic for editing, the markdown editor removes all newlines (unless there are two newlines in a row) when rendering the markdown into html.

This is important as we begin to invest more time and energy into the EigenDA docs.

Advantages:
* Reads better on github diffs
* Easier to navigate lines on a code editor, since each line is on a real line (paragraphs are not just one long line).
* Looks the same regardless of screen width if you have word wrap off.

Notes:
* I only changed this on the EigenDA section of the site.
* I made sure not to break lists, links, etc with this. 