### PR TITLE
Fix redirection for terms of service

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
           },
           {
             from: "/overview/terms-of-service",
-            to: "/eigenlayer/legal/eigenlayer-privacy-policy",
+            to: "/eigenlayer/legal/eigenlayer-terms-of-service",
           },
           // This is implicit, covered by the function case below
           // {


### PR DESCRIPTION
Terms of services was redirected to the privacy policy previously, by changing it to the good redirection it will be fixed.