### PR TITLE
Fix naming convention, typo, format, and support desk link

### DIFF
--- a/docs/eigenda/integrations-overview.md
+++ b/docs/eigenda/integrations-overview.md
@@ -100,7 +100,7 @@ finalization.
 First, L2 chain finalization. An L2 transaction is finalized with respect to the
 L2 chain when the transaction has been sequenced in the L2 inbox contract. When
 this process is complete, any L2 node can say with confidence that the
-transaction is part of the cannonical L2 chain and is not subject to a reorg.
+transaction is part of the canonical L2 chain and is not subject to a reorg.
 
 For example, if you were selling your car and a buyer paid you by sending you a
 USDC on a secure rollup, it would be important to wait until the transaction had
@@ -216,7 +216,7 @@ of the L2 VM design works as-is for arbitrating fraud.
 <!-- ![M2 chain finalization](/img/eigenda/optimistic-M2-dispersal.png) -->
 
 The V2 integration strategy is similar to the V1 integration strategy, with the
-differece that EigenDA certificates are not verified on Ethereum. Instead, they
+difference that EigenDA certificates are not verified on Ethereum. Instead, they
 are verified within the L2 itself, such that the validity of DA certs is
 enforced by the same fraud proof mechanism that is used with all other L2 state.
 In this mode, a rollup batcher may submit invalid EigenDA certs to the rollup
@@ -227,7 +227,7 @@ cert, it is possible to successfully challenge that state root.
 This integration strategy depends on the ability of the L2 OS to validate
 EigenDA certs, which requires an authenticated view into the current EigenDA
 operator set. Specifically, the L2 OS must have access to L1 state roots, so
-that Eigenlayer contract storage proofs may be verified.
+that EigenLayer contract storage proofs may be verified.
 
 ## Analysis
 

--- a/docs/eigenda/operator-guides/eigenda-metrics-and-monitoring.md
+++ b/docs/eigenda/operator-guides/eigenda-metrics-and-monitoring.md
@@ -18,28 +18,28 @@ cp .env.example .env
 - Open the `.env` file, ensure the location of `prometheus.yml` is correct for your environment.
 - In the `prometheus.yml` file:
   - Update prometheus config [file](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/monitoring/prometheus.yml)
-    is updated with the metrics port (`NODE_METRICS_PORT`) of the eigenda node in parent folder `.env` file
-  - Ensure the eigenda container name for `scrape_configs.targets` matches the value of the parent folder `.env` file (`MAIN_SERVICE_NAME`).
+    is updated with the metrics port (`NODE_METRICS_PORT`) of the EigenDA node in parent folder `.env` file
+  - Ensure the EigenDA container name for `scrape_configs.targets` matches the value of the parent folder `.env` file (`MAIN_SERVICE_NAME`).
   - Make sure the location of prometheus file is correct in [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/monitoring/.env.example) file
 
-**Step 2:** Run the following command to start the monitoring stack
+**Step 2:** Run the following command to start the monitoring stack:
 
 ```
 docker compose up -d
 ```
 
-**Step 3:** Since eigenda is running in a different docker network we will need
-to have prometheus in the same network. To do that, run the following command
+**Step 3:** Since EigenDA is running in a different docker network, we will need
+to have prometheus in the same network. To do that, run the following command:
 
 ```
-docker network connect eigenda-network prometheus
+docker network connect `eigenda-network` prometheus
 ```
 
-Note: `eigenda-network` is the name of the network in which eigenda is running.
-You can check the network name in eigenda
+Note: `eigenda-network` is the name of the network in which EigenDA is running.
+You can check the network name in EigenDA
 [.env](https://github.com/Layr-Labs/eigenda-operator-setup/blob/master/.env.example#L2)
 file (`NETWORK_NAME`). This will ensure Prometheus can scrape the metrics from
-Eigenda node.
+EigenDA node.
 
 Useful Dashboards: EigenDA offers a set of [Grafana
 dashboards](https://github.com/Layr-Labs/eigenda-operator-setup/tree/master/monitoring/dashboards)

--- a/docs/eigenda/operator-guides/operator-faq.md
+++ b/docs/eigenda/operator-guides/operator-faq.md
@@ -19,7 +19,7 @@ If none of this reason applies, please reach out to EigenLayer Support
 
 #### How do I know if my node is signing EigenDA blobs correctly?
 
-There are few ways you can confirm that your node is signing the blobs
+There are few ways you can confirm that your node is signing the blobs:
 
 * Ensure that you have monitoring setup according to the
  [guide](./eigenda-metrics-and-monitoring.md). Once you have added the provided
@@ -52,8 +52,8 @@ traffic, make sure [your network settings
 allows](./eigenda-avs-installation-registration-and-upgrade.md#step-3-operator-networking-security-setup)
 EigenDA's disperser to reach your node.
 
-If you were previously opted-in and was signing, it's possible you are [churned
-out](./overview.md#eigenda-churn-approver) by an other operator or you have been
+If you were previously opted-in and were signing, it's possible you are [churned
+out](./overview.md#eigenda-churn-approver) by another operator or you have been
 [ejected due to non-signing](./ejection-non-signing.md). Please try opting-in
 again.
 
@@ -61,9 +61,9 @@ again.
 
 If you are running on k8s or have a load balancer in front of your EigenDA node
 and you don't want EigenDA to automatically update IP which is sent to EigenDA
-while registeration then follow the steps to make sure correct IP is registered
+while registration then follow the steps to make sure correct IP is registered:
 
-* Update the [NODE_HOSTNAME](https://github.com/Layr-Labs/eigenda-operator-setup/blob/2872d76b5e0b127400eb7e6dd16da362c7c142ba/.env.example#L63) to the public IP where you will want to recieve traffic.
+* Update the [NODE_HOSTNAME](https://github.com/Layr-Labs/eigenda-operator-setup/blob/2872d76b5e0b127400eb7e6dd16da362c7c142ba/.env.example#L63) to the public IP where you will want to receive traffic.
 * Opt-in using the provided [steps](./eigenda-avs-installation-registration-and-upgrade.md#step-4-opt-in-into-eigenda)
 * Update the [NODE_PUBLIC_IP_CHECK_INTERVAL](https://github.com/Layr-Labs/eigenda-operator-setup/blob/2872d76b5e0b127400eb7e6dd16da362c7c142ba/.env.example#L57) to `0` to disable automatic IP update
 * Run the EigenDA node

--- a/docs/eigenda/operator-guides/overview.md
+++ b/docs/eigenda/operator-guides/overview.md
@@ -62,7 +62,7 @@ and explicitly communicate future changes.  :::
 
 In order to determine the current TVL of the top 200 operators, please visit our
 [AVS page](https://goerli.eigenlayer.xyz/avs/eigenda) and sort by `TVL
-Ascending.`Observe the first 200 operators listed and the amount of ETH TVL
+Ascending`. Observe the first 200 operators listed and the amount of ETH TVL
 delegated to them.
 
 When a new operator wants to opt-in but EigenDA has reached its operator cap,
@@ -93,7 +93,7 @@ Operators that have been ejected can verify the change in two ways:
 in the active operator set on the [AVS page](https://goerli.eigenlayer.xyz/avs/eigenda).
 2. Observe your EigenDA Operator log for the following logs. If you see this
 consistently, then your operator is not receiving any disperser traffic and you
-may have been ejected.  This is not an error but if you only see this log line
+may have been ejected. This is not an error but if you only see this log line
 repeatedly then it means you may not be receiving any disperser traffic.
 
 ```

--- a/docs/eigenda/rollup-guides/op-stack/README.md
+++ b/docs/eigenda/rollup-guides/op-stack/README.md
@@ -30,7 +30,7 @@ are detailed in the next section.**
 
 ## How it works
 
-![OP stack digram](/img/op-stack-blob-disersal-seq.png)
+![OP stack diagram](/img/op-stack-blob-disersal-seq.png)
 
 In the absence of fraud proofs, the integration is relatively simple. On the
 sequencing side instead of writing L2 transaction data to Ethereum calldata, we

--- a/docs/eigenda/rollup-guides/op-stack/deploying-op-stack-+-eigenda-locally.md
+++ b/docs/eigenda/rollup-guides/op-stack/deploying-op-stack-+-eigenda-locally.md
@@ -51,7 +51,7 @@ cd inabox make clean new-anvil deploy-all ./bin.sh start
 # To clean up Ctrl+C to quit EigenDA
 
 # then to stop anvil, the graph and localstack
-make stop-infra 
+make stop-infra
 ```
 
 ## Running OpStack Locally
@@ -65,7 +65,7 @@ git submodule update --init --recursive
 
 # install and use correct golang version
 
-gvm intall $(cat .go-version) gvm use $(cat .go-version)
+gvm install $(cat .go-version) gvm use $(cat .go-version)
 
 # build correct foundry version from source (may take a few minutes)
 

--- a/docs/eigenda/rollup-guides/tutorial.md
+++ b/docs/eigenda/rollup-guides/tutorial.md
@@ -118,9 +118,10 @@ Data Availability is a requirement for both for ZK and Optimistic rollups
 
 - In both optimistic rollups and ZK-rollups, if transaction data is not
 available, then participants in the rollup will be unable to reconstruct the
-rollup state so as to bridge out their assets if desired.  - In optimistic
-rollups, if transaction data is not available, challengers are unable to check
-the sequencer’s state commitment and create fraud proofs when applicable.
+rollup state so as to bridge out their assets if desired.
+- In optimistic rollups, if transaction data is not available, challengers are
+unable to check the sequencer’s state commitment and create fraud proofs when
+applicable.
 
 **Verifying Blob Availability On Chain**
 

--- a/docs/eigenlayer/operator-guides/operator-installation.md
+++ b/docs/eigenlayer/operator-guides/operator-installation.md
@@ -149,7 +149,6 @@ Please backup the above private key hex in safe place.
 Key location: /home/ubuntu/.eigenlayer/operator_keys/test.ecdsa.key.json
 Public Key hex:  f87ee475109c2943038b3c006b8a004ee17bebf3357d10d8f63ef202c5c28723906533dccfda5d76c1da0a9f05cc6d32085ca1af8aaab5a28171474b1ad0aa68
 Ethereum Address 0x6a8c0D554a694899041E52a91B4EC3Ff23d8aBD5
-
 ```
 
 ### Import Keys
@@ -247,7 +246,7 @@ You can create the config files needed for operator registration using the below
 eigenlayer operator config create
 ```
 
-When prompted for operator address, make sure your operator address is same as the ecdsa key address you created/imported in key creation steps. 
+When prompted for operator address, make sure your operator address is same as the ecdsa key address you created/imported in key creation steps.
 
 It will create two files: `operator.yaml` and `metadata.json` After filling the details in `metadata.json`, please upload this into a publicly accessible location and fill that url in `operator.yaml`. A valid metadata url is required for successful registration. An example operator.yaml file is provided for your reference here: [operator.yaml](https://github.com/Layr-Labs/eigenlayer-cli/blob/master/pkg/operator/config/operator-config-example.yaml) .
 

--- a/docs/eigenlayer/operator-guides/troubleshooting.md
+++ b/docs/eigenlayer/operator-guides/troubleshooting.md
@@ -4,12 +4,12 @@ sidebar_position: 5
 
 # Troubleshooting
 
-Before creating an issue with EigenLayer support please check this page to see if you can resolve your issues. If you are still stuck, please create a support ticket
+Before creating an issue with EigenLayer Support, please check this page to see if you can resolve your issues. If you are still stuck, please create a support ticket with <a href="javascript:void(0)"  id="intercom_trigger_eldocs" >EigenLayer Support Desk</a>.
 
 #### Getting "no contract code at given address"
 
 If you are getting this issue then either you are using a wrong rpc in your [operator.yaml](https://github.com/Layr-Labs/eigenlayer-cli/blob/master/pkg/operator/config/operator-config-example.yaml#L32) file or you have wrong smart contract address in your [config](https://github.com/Layr-Labs/eigenlayer-cli/blob/master/pkg/operator/config/operator-config-example.yaml#L25).
 
-* Please make sure you have correct rpc (goerli rpc for goerli nodes, mainnet rpc for mainnet) and is also accessible via your machine
+- Please make sure you have correct rpc (goerli rpc for goerli nodes, mainnet rpc for mainnet) and is also accessible via your machine.
 
-* Please find the correct smart contract addresses [here](./operator-installation#goerli-smart-contract-addresses)
+- Please find the correct smart contract addresses [here](./operator-installation#goerli-smart-contract-addresses).

--- a/docs/eigenlayer/restaking-guides/0-restaking-user-guide/native-restaking/README.md
+++ b/docs/eigenlayer/restaking-guides/0-restaking-user-guide/native-restaking/README.md
@@ -4,7 +4,7 @@ description: How to restake and withdraw with Native Staking
 
 # Native Restaking
 
-Native Restaking is the process of pointing an Ethereum validator's [withdrawal credentials](https://notes.ethereum.org/@launchpad/withdrawals-faq#Q-What-are-withdrawals) to the user's [EigenPod](./create-eigenpod/README.md). You must operate an Ethereum Validator node in order to participate in Native Restaking. To learn more or set up your Ethereum Validator please follow this link from the[ Ethereum Foundation](https://goerli.launchpad.ethereum.org/).
+Native Restaking is the process of pointing an Ethereum validator's [withdrawal credentials](https://notes.ethereum.org/@launchpad/withdrawals-faq#Q-What-are-withdrawals) to the user's [EigenPod](./create-eigenpod/README.md). You must operate an Ethereum Validator node in order to participate in Native Restaking. To learn more or set up your Ethereum Validator please follow this link from the [Ethereum Foundation](https://goerli.launchpad.ethereum.org/).
 
 :::info
 Please read this entire guide before launching your new validator or integrating your existing validator. Before you deploy a new validator you must plan to either:


### PR DESCRIPTION
Fixed some minor offs found while reading the doc, including:
- Spelling errors
- Standardization naming
- Formatting issues
- Add necessary support desk link