### PR TITLE
Add Alpine Linux to operator-installation.md

### DIFF
--- a/docs/eigenlayer/operator-guides/operator-installation.md
+++ b/docs/eigenlayer/operator-guides/operator-installation.md
@@ -10,6 +10,7 @@ sidebar_position: 2
 
 - Docker: Ensure that Docker is installed on your system. To download Docker, follow the instructions listed [here](https://docs.docker.com/get-docker/).
 - Docker Compose: Make sure Docker Compose is also installed and properly configured. To download Docker Compose, follow the instructions listed [here](https://docs.docker.com/compose/install/).
+- Alpine Linux: To Install Docker follow the instructions listed [here](https://wiki.alpinelinux.org/wiki/Docker#Installation)
 - Linux Environment: EigenLayer is supported only on Linux. Ensure you have a Linux environment, such as Docker, for installation.
   - If you choose to install eigenlayer-cli using the Go programming language, ensure you have Go installed, version 1.21 or higher. You can find the installation guide [here](https://go.dev/doc/install).
 


### PR DESCRIPTION
What ?

Added docker instructions for Alpine Linux

Why ?

Alpine Linux is widely known to be the best way to run Docker in Linux. I have used it on many occasions and its been great.

" In 2016,  Docker decided to switch the official Docker image library from Ubuntu to Alpine"
https://thenewstack.io/alpine-linux-heart-docker/

