### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-* @wesfloyd @eigensid @joan-el @QuinnLee @ropcode @bpm6867 @cpdcpd @cjlayr @shrimalmadhur @tinahaibodi @wadealexc @teddyknox @NimaVaziri @dabit3 @siddimore @bpm333
+* @eigensid @teddyknox @dabit3 @wesfloyd @tinahaibodi
+docs/eigenlayer/ @bpm333 @joan-el @scotthconner @QuinnLee
+docs/eigenlayer/security @ropcode @antojoseph @anupsv @wadealexc
+docs/eigenlayer/avs-guides/ @NimaVaziri @afkbyte @stevennevins @samlaf @0xkydo
+docs/eigenlayer/risk/ @0xkydo @cryptogakusei 
+docs/eigenda/ @teddyknox @eigensid @jianoaix @mooselumph


### PR DESCRIPTION
Plan:
1. Reset the codeowners file to just a few owners to reduce confusion.
2. Add team-specific codeowners