### PR TITLE
Fixed a link issue in the Overview page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,7 +28,7 @@ function Home() {
             <div className="container">
               <div className="row cards__container">
                 <Card
-                  to="eigenlayer/overview"
+                  to="eigenlayer/overview/"
                   header={{
                     label:"Intro to EigenLayer"
                   }}


### PR DESCRIPTION
**Description:**
After entering the overview [page ](https://docs.eigenlayer.xyz/eigenlayer/overview)directly from the [document portal](https://docs.eigenlayer.xyz/), there is no '/' at the end of the page link by default, which causes the hyperlink on the overview page to not work properly, so I added '/' to the portal page and fixed this problem.

There is no impact on the structure or other aspects of the document, just this small bug is fixed.

**Related issues:**
#128 

Thank you for reviewing and merging!

![image](https://github.com/Layr-Labs/eigenlayer-docs/assets/42063103/2007c080-e2f7-4e56-b1ef-8fda576461bc)
