### PR TITLE
Remove invalid markdown link in operator-installation.md

### DIFF
--- a/docs/eigenlayer/operator-guides/operator-installation.md
+++ b/docs/eigenlayer/operator-guides/operator-installation.md
@@ -267,7 +267,7 @@ An example list of providers is [available here](https://www.alchemy.com/list-of
 
 For operator registration in a Holesky environment, you need to set the DelegationManager contract address as follows:
 
-[Current Testnet Deployment](Current Testnet Deployment): Holesky DelegationManager: [`0xA44151489861Fe9e3055d95adC98FbD462B948e7`](https://holesky.etherscan.io/address/0xA44151489861Fe9e3055d95adC98FbD462B948e7).
+Current DelegationManager on Holesky testnet: [`0xA44151489861Fe9e3055d95adC98FbD462B948e7`](https://holesky.etherscan.io/address/0xA44151489861Fe9e3055d95adC98FbD462B948e7).
 
 ```
 # EigenLayer Delegation Manager contract address


### PR DESCRIPTION
stumbled upon a small markdown inconsistency in the operator docs