### PR TITLE
fix ill formatted doc in operator installation guide

### DIFF
--- a/docs/eigenlayer/operator-guides/operator-installation.md
+++ b/docs/eigenlayer/operator-guides/operator-installation.md
@@ -267,7 +267,7 @@ An example list of providers is [available here](https://www.alchemy.com/list-of
 
 For operator registration in a Holesky environment, you need to set the DelegationManager contract address as follows:
 
-[Current Testnet Deployment](Current Testnet Deployment): Holesky DelegationManager: [`0xA44151489861Fe9e3055d95adC98FbD462B948e7`](https://holesky.etherscan.io/address/0xA44151489861Fe9e3055d95adC98FbD462B948e7).
+Current Testnet Deployment - Holesky DelegationManager: [`0xA44151489861Fe9e3055d95adC98FbD462B948e7`](https://holesky.etherscan.io/address/0xA44151489861Fe9e3055d95adC98FbD462B948e7).
 
 ```
 # EigenLayer Delegation Manager contract address


### PR DESCRIPTION
fix ill formatted doc in operator installation guide, which looks as below

![image](https://github.com/Layr-Labs/eigenlayer-docs/assets/1892692/e0877dd9-dd6c-49fb-9d9d-541cb9f3a531)

