### PR TITLE
fix grpcurl, making it compatible with the new 4844 format

### DIFF
--- a/docs/eigenda/rollup-guides/tutorial.md
+++ b/docs/eigenda/rollup-guides/tutorial.md
@@ -54,7 +54,7 @@ $ gh repo clone Layr-Labs/eigenda
 # protobuf defintions correctly
 $ cd eigenda
 
-$ grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d '{"data": "hello"}' disperser-holesky.eigenda.xyz:443 disperser.Disperser/DisperseBlob
+$ grpcurl -import-path ./api/proto -proto ./api/proto/disperser/disperser.proto -d '{"data": "LWhlbGxvLQ=="}' disperser-holesky.eigenda.xyz:443 disperser.Disperser/DisperseBlob
 ```
 
 **Step 2: Validate the blob was stored in a batch**


### PR DESCRIPTION
The current grpcurl command on "https://docs.eigenlayer.xyz/eigenda/rollup-guides/tutorial" will return an error message.

<img width="988" alt="Screenshot 2024-04-05 at 6 17 25 PM" src="https://github.com/Layr-Labs/eigenlayer-docs/assets/93296844/b1ae6174-c017-4c5f-8a79-527bdee6867a">

It is due to the recent change on the EigenDA blob interface, moreover, proto is expecting a base64 encoding.

The replaced string is a base64 encoding for "-hello-".