### PR TITLE
Fix update TVL sort order

### DIFF
--- a/docs/eigenda/operator-guides/requirements/delegation-requirements.mdx
+++ b/docs/eigenda/operator-guides/requirements/delegation-requirements.mdx
@@ -42,7 +42,7 @@ Details about how these requirements are enforced and the process by which DA no
 
 In order to determine the current TVL of the top 200 operators for each quorum, please visit our
 AVS page ([Mainnet](https://app.eigenlayer.xyz/avs/eigenda), [Holesky](https://holesky.eigenlayer.xyz/avs/eigenda)) and sort by `TVL
-Ascending.` Observe the first 200 operators listed for the quorum and the amount of ETH TVL
+Descending.` Observe the first 200 operators listed for the quorum and the amount of ETH TVL
 delegated to them. Please keep in mind that the AVS Page reflects the
 operator stake on EigenLayer, which is used to update the EigenDA operator set
 stake weights on a weekly basis (Wednesdays at 17:00 UTC), so the EigenDA stake


### PR DESCRIPTION
To view the top 200 operators, the list should be sorted in descending order to display the operators with more stake first.