### PR TITLE
Update avssync interval

### DIFF
--- a/docs/eigenda/networks/holesky.md
+++ b/docs/eigenda/networks/holesky.md
@@ -22,6 +22,7 @@ The EigenDA Holesky testnet is the current EigenDA testnet. The EigenDA Holesky 
 | Max Blob Size | 2 MB |
 | Default Blob Dispersal Rate limit | No more than 1 blob every 100 seconds |
 | Default Blob Size Rate Limit | No more than 1.8 MB every 10 minutes |
+| Stake Sync (AVS-Sync) Interval | Every 24 hours |
 
 [1]: https://blobs-holesky.eigenda.xyz/
 [2]: https://holesky.eigenlayer.xyz/avs/eigenda

--- a/docs/eigenda/networks/mainnet.md
+++ b/docs/eigenda/networks/mainnet.md
@@ -18,6 +18,7 @@ sidebar_position: 3
 | Churner Address | `churner.eigenda.xyz:443` |
 | Batch Confirmation Interval | Every 10 minutes (may vary based on network health) |
 | Max Blob Size | 2 MB |
+| Stake Sync (AVS-Sync) Interval | Every 6 days |
 
 [1]: https://blobs.eigenda.xyz/
 [2]: https://app.eigenlayer.xyz/avs/0x870679e138bcdf293b7ff14dd44b70fc97e12fc0

--- a/docs/eigenda/operator-guides/run-a-node/registration.mdx
+++ b/docs/eigenda/operator-guides/run-a-node/registration.mdx
@@ -68,7 +68,7 @@ If you meet the delegation requirements for opting into one or more quorums, you
 
 
 :::warning
-Operators must wait up to 24 hours if the delegation happened after you opt-in to the EigenDA AVS. EigenLayer's AVS-Sync component runs at 24 hour batch intervals to update the delegation totals on chain for each operator. If you are unable to opt in despite having sufficient delegated stake, please wait at least 24 hours, then retry opt-in.
+Operators must wait for their stakes to be synced if the delegation happened after you opt-in to the EigenDA AVS. EigenLayer's AVS-Sync component runs at certain intervals to update the delegation totals on chain for each operator. If you are unable to opt in despite having sufficient delegated stake, please wait at least the amount necessary for staked to be synced, then retry opt-in. This sync interval varies for different networks and you can check [here](https://docs.eigenlayer.xyz/eigenda/networks/).
 :::
 
 


### PR DESCRIPTION
- Pulling out avssync intervals to the network parameters page
- Updating mainnet avssync interval to 6 days

## Mainnet
<img width="700" alt="Screenshot 2024-07-02 at 11 15 58 AM" src="https://github.com/Layr-Labs/eigenlayer-docs/assets/100327837/16026ac8-5bad-466b-abec-92d0fd82ff39">

## Testnet
<img width="702" alt="Screenshot 2024-07-02 at 11 42 03 AM" src="https://github.com/Layr-Labs/eigenlayer-docs/assets/100327837/00352cf8-073b-48d0-afdf-65138f0f31b4">


<img width="968" alt="Screenshot 2024-07-02 at 11 15 53 AM" src="https://github.com/Layr-Labs/eigenlayer-docs/assets/100327837/11479a10-c069-418b-b2ea-fe7e040cfe16">
