### PR TITLE
Updating and simplifying CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @dabit3 @wesfloyd @bryangreen @shrimalmadhur @antojoseph @NimaVaziri @scotthconner
+* @dabit3 @wesfloyd @bryangreen @shrimalmadhur @antojoseph @NimaVaziri @scotthconner @MC1823315 @nelsonijih
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,2 @@
-* @bryangreen @teddyknox @dabit3 @wesfloyd
-docs/eigenlayer/  @teddyknox @dabit3 @wesfloyd  @bpm333 @joan-el @scotthconner @QuinnLee
-docs/eigenlayer/security  @teddyknox @dabit3 @wesfloyd @antojoseph @anupsv @wadealexc
-docs/eigenlayer/avs-guides/  @teddyknox @dabit3 @wesfloyd  @bpm333 @joan-el @scotthconner @QuinnLee @NimaVaziri @afkbyte @stevennevins @samlaf @0xkydo
-docs/eigenlayer/risk/ @0xkydo  @teddyknox @dabit3 @wesfloyd  @cryptogakusei 
-docs/eigenda/  @teddyknox @dabit3 @wesfloyd  @teddyknox  @jianoaix @mooselumph
+* @dabit3 @wesfloyd @bryangreen @shrimalmadhur @antojoseph @NimaVaziri @scotthconner
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @dabit3 @wesfloyd @bryangreen @shrimalmadhur @antojoseph @NimaVaziri @scotthconner @MC1823315 @nelsonijih
+* @dabit3 @wesfloyd @bryangreen @shrimalmadhur @antojoseph @NimaVaziri @scotthconner @MC1823315 @nelsonijih @QuinnLee
 


### PR DESCRIPTION
Simplifying the codeowners file structure
Removing team members that no longer exist in the org

(Future PR: will move away from the CODEOWNERS file in lieu of standard git repo permissions)