### PR TITLE
Update rewards-snapshot-data.md to correct claim file format

### DIFF
--- a/docs/eigenlayer/rewards-claiming/rewards-snapshot-data.md
+++ b/docs/eigenlayer/rewards-claiming/rewards-snapshot-data.md
@@ -21,7 +21,7 @@ Rewards snapshot distribution data is available via a public S3 bucket. Users ma
 
 2) Construct the URL to return the claim-amounts.json file for the desired snapshot date in the following format:
 
-`https://<bucket url>/<environment>/<network>/<snapshot date>/claim-amounts.json`
+`<bucket url>/<environment>/<network>/<snapshot date>/claim-amounts.json`
 
 * bucket_url: 
   * [https://eigenlabs-rewards-testnet-holesky.s3.amazonaws.com](https://eigenlabs-rewards-testnet-holesky.s3.amazonaws.com)


### PR DESCRIPTION
`<bucket_url>` already contains `https://`, remove it from the base format