### PR TITLE
Update operator-installation.md

### DIFF
--- a/docs/eigenlayer/operator-guides/operator-installation.md
+++ b/docs/eigenlayer/operator-guides/operator-installation.md
@@ -332,7 +332,7 @@ eigenlayer operator update operator.yaml
 ```
 
 ### Update metadata URI (Post v0.9.0)
-In [v0.9.0](https://github.com/Layr-Labs/eigenlayer-cli/releases/tag/v0.9.0), we have introduced a new comamnd to update metadata uri.
+In [v0.9.0](https://github.com/Layr-Labs/eigenlayer-cli/releases/tag/v0.9.0), we have introduced a new command to update metadata uri.
 
 ```
 eigenlayer operator update-metadata-uri operator.yaml


### PR DESCRIPTION
Fix minor typo at the [Installation and Registration](https://docs.eigenlayer.xyz/eigenlayer/operator-guides/operator-installation) page.

update this typo from "**comamnd**" to "**command**" 

![image](https://github.com/user-attachments/assets/35e28b8a-51ca-4a7f-9e01-0fc35fac7830)
