### PR TITLE
Update (withdrawal) mainnet escrow period from 7-days to 14-days

### DIFF
--- a/docs/restakers/restaking-guides/testnet/README.md
+++ b/docs/restakers/restaking-guides/testnet/README.md
@@ -16,6 +16,6 @@ Users are encouraged to first test their staking approach on the Holesky Testnet
 
 - Withdraw (Escrow) Period:
     - All funds unstaked from _EigenLayer Testnet_ go through a delay (escrow period) of 10 blocks (roughly 2 minutes) before being able to be withdrawn.
-    - Liquid tokens and Native Restaking funds unstaked from _EigenLayer Mainnet_ will go through a 7-day escrow period before being able to be withdrawn.
+    - Liquid tokens and Native Restaking funds unstaked from _EigenLayer Mainnet_ will go through a 14-day escrow period before being able to be withdrawn.
 - Testnet includes the Slashing and Operator Sets upgrade. Please see [ELIP-002: Slashing via Unique Stake & Operator Sets](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md) for more information.
 


### PR DESCRIPTION
Updating the mainnet escrow period in the docs from 7-days to 14-days as per the code in the Delegation Manager smart contract, see here: [https://github.com/Layr-Labs/eigenlayer-contracts/blob/e35e7d35ad91c1070420818896a60f021f3b5fab/docs/core/DelegationManager.md?plain=1#L38](https://github.com/Layr-Labs/eigenlayer-contracts/blob/e35e7d35ad91c1070420818896a60f021f3b5fab/docs/core/DelegationManager.md?plain=1#L38)

Doing this as I was initially confused by the docs of why a withdrawal was not available.